### PR TITLE
feat(llm-providers): ToolCallingLlmProvider — Anthropic, OpenAI, Gemini adapters (STF #5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { McpClient, createMcpClient } from './mcp-client';
+export type { McpClientOptions, McpTool, McpCallResult } from './mcp-client';
 export { normalizeScreenPath } from './screen-path';
 export type { SyntheticConfig } from './config';
 export { loadSyntheticConfig } from './config';

--- a/src/llm-providers/anthropic.ts
+++ b/src/llm-providers/anthropic.ts
@@ -1,0 +1,94 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class AnthropicToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'claude-sonnet-4-6', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `anthropic-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['ANTHROPIC_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('@anthropic-ai/sdk' as string).catch(() => {
+      throw new Error('AnthropicToolCallingProvider requires @anthropic-ai/sdk');
+    }) as { default: new (opts: { apiKey: string }) => any };
+
+    const client = new mod.default({ apiKey: this.apiKey });
+
+    const response = await client.messages.create({
+      model: this.model,
+      max_tokens: options.maxTokens ?? 4096,
+      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+      tools: tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.parameters,
+      })),
+      messages: this.formatMessages(messages),
+    }) as { content: Array<{ type: string; id?: string; name?: string; input?: unknown; text?: string }> };
+
+    const toolCalls = response.content
+      .filter(b => b.type === 'tool_use')
+      .map(b => ({
+        id: b.id!,
+        name: b.name!,
+        args: this.safeParseArgs(b.input),
+      }));
+
+    const text = response.content
+      .filter(b => b.type === 'text')
+      .map(b => b.text ?? '')
+      .join('');
+
+    return {
+      ...(text ? { content: text } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Tool results go in a user message as tool_result content blocks
+        result.push({
+          role: 'user',
+          content: msg.toolResults.map(r => ({
+            type: 'tool_result',
+            tool_use_id: r.toolCallId,
+            content: r.content,
+          })),
+        });
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'assistant',
+          content: msg.toolCalls.map(tc => ({
+            type: 'tool_use',
+            id: tc.id,
+            name: tc.name,
+            input: tc.args,
+          })),
+        });
+      } else {
+        result.push({ role: msg.role, content: msg.content ?? '' });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(input: unknown): Record<string, unknown> {
+    if (typeof input === 'object' && input !== null) return input as Record<string, unknown>;
+    if (typeof input === 'string') {
+      try { return JSON.parse(input); } catch { return {}; }
+    }
+    return {};
+  }
+}

--- a/src/llm-providers/gemini.ts
+++ b/src/llm-providers/gemini.ts
@@ -77,19 +77,27 @@ export class GeminiToolCallingProvider implements ToolCallingLlmProvider {
 
   private formatMessages(messages: Message[]): unknown[] {
     const result: unknown[] = [];
+    // Gemini's functionResponse.name must match the declared function name, not the
+    // synthetic ID (gemini-call-N). Populate this map when we see an assistant turn so
+    // the next user/tool-result turn can look up the real name.
+    const toolNameById = new Map<string, string>();
+
     for (const msg of messages) {
       if (msg.role === 'user' && msg.toolResults) {
-        // Tool results as functionResponse parts in a user turn
         result.push({
           role: 'user',
           parts: msg.toolResults.map(r => ({
             functionResponse: {
-              name: r.toolCallId, // Gemini matches by function name, not ID
+              name: toolNameById.get(r.toolCallId) ?? r.toolCallId,
               response: { content: r.content },
             },
           })),
         });
       } else if (msg.role === 'assistant' && msg.toolCalls) {
+        toolNameById.clear();
+        for (const tc of msg.toolCalls) {
+          toolNameById.set(tc.id, tc.name);
+        }
         result.push({
           role: 'model',
           parts: msg.toolCalls.map(tc => ({

--- a/src/llm-providers/gemini.ts
+++ b/src/llm-providers/gemini.ts
@@ -1,0 +1,116 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class GeminiToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'gemini-1.5-pro', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `gemini-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['GEMINI_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('@google/generative-ai' as string).catch(() => {
+      throw new Error('GeminiToolCallingProvider requires @google/generative-ai');
+    }) as { GoogleGenerativeAI: new (key: string) => any };
+
+    const client = new mod.GoogleGenerativeAI(this.apiKey);
+    const genConfig: Record<string, number> = {};
+    if (options.temperature !== undefined) genConfig['temperature'] = options.temperature;
+    if (options.maxTokens !== undefined) genConfig['maxOutputTokens'] = options.maxTokens;
+
+    const genModel = client.getGenerativeModel({
+      model: this.model,
+      ...(Object.keys(genConfig).length > 0 ? { generationConfig: genConfig } : {}),
+      tools: [{
+        // SDK uses camelCase functionDeclarations
+        functionDeclarations: tools.map(t => ({
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        })),
+      }],
+    });
+
+    const contents = this.formatMessages(messages);
+    const result = await genModel.generateContent({ contents }) as {
+      response: {
+        candidates?: Array<{
+          content?: {
+            parts?: Array<{
+              text?: string;
+              functionCall?: { name: string; args: unknown };
+            }>;
+          };
+        }>;
+        text(): string;
+      };
+    };
+
+    const parts = result.response.candidates?.[0]?.content?.parts ?? [];
+
+    const toolCalls = parts
+      .filter(p => p.functionCall)
+      .map((p, i) => ({
+        id: `gemini-call-${i}`,  // Gemini doesn't provide call IDs — generate positional ones
+        name: p.functionCall!.name,
+        args: this.safeParseArgs(p.functionCall!.args),
+      }));
+
+    const text = parts
+      .filter(p => p.text)
+      .map(p => p.text!)
+      .join('');
+
+    return {
+      ...(text ? { content: text } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Tool results as functionResponse parts in a user turn
+        result.push({
+          role: 'user',
+          parts: msg.toolResults.map(r => ({
+            functionResponse: {
+              name: r.toolCallId, // Gemini matches by function name, not ID
+              response: { content: r.content },
+            },
+          })),
+        });
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'model',
+          parts: msg.toolCalls.map(tc => ({
+            functionCall: { name: tc.name, args: tc.args },
+          })),
+        });
+      } else {
+        result.push({
+          role: msg.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text: msg.content ?? '' }],
+        });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(args: unknown): Record<string, unknown> {
+    if (typeof args === 'object' && args !== null) return args as Record<string, unknown>;
+    if (typeof args === 'string') {
+      try { return JSON.parse(args); } catch { return {}; }
+    }
+    return {};
+  }
+}

--- a/src/llm-providers/index.ts
+++ b/src/llm-providers/index.ts
@@ -1,0 +1,41 @@
+export type {
+  ToolDefinition,
+  ToolCall,
+  ToolResult,
+  Message,
+  ChatResponse,
+  ChatOptions,
+  ToolCallingLlmProvider,
+} from './types';
+export { AnthropicToolCallingProvider } from './anthropic';
+export { OpenAIToolCallingProvider } from './openai';
+export { GeminiToolCallingProvider } from './gemini';
+
+import type { ToolCallingLlmProvider } from './types';
+import { AnthropicToolCallingProvider } from './anthropic';
+import { OpenAIToolCallingProvider } from './openai';
+import { GeminiToolCallingProvider } from './gemini';
+
+/**
+ * Resolve a ToolCallingLlmProvider from LISA_LLM_PROVIDER env var.
+ * Returns undefined when LISA_LLM_PROVIDER is unset — caller falls back to
+ * the existing LlmProvider / Claude CLI default path.
+ */
+export function resolveToolCallingProvider(): ToolCallingLlmProvider | undefined {
+  const p = process.env['LISA_LLM_PROVIDER'];
+  if (!p) return undefined;
+
+  const lower = p.toLowerCase();
+  if (lower === 'anthropic' || lower === 'claude') {
+    return new AnthropicToolCallingProvider();
+  }
+  if (lower === 'openai') {
+    return new OpenAIToolCallingProvider();
+  }
+  if (lower === 'gemini') {
+    return new GeminiToolCallingProvider();
+  }
+  throw new Error(
+    `Unknown LISA_LLM_PROVIDER: "${p}". Valid values: anthropic, openai, gemini`,
+  );
+}

--- a/src/llm-providers/llm-providers.test.ts
+++ b/src/llm-providers/llm-providers.test.ts
@@ -1,0 +1,339 @@
+import { AnthropicToolCallingProvider } from './anthropic';
+import { OpenAIToolCallingProvider } from './openai';
+import { GeminiToolCallingProvider } from './gemini';
+import { resolveToolCallingProvider } from './index';
+import type { ToolDefinition, Message } from './types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TOOL: ToolDefinition = {
+  name: 'lisa_health',
+  description: 'Check server health',
+  parameters: { type: 'object', properties: { verbose: { type: 'boolean' } } },
+};
+
+const USER_MSG: Message = { role: 'user', content: 'Check health' };
+
+// ---------------------------------------------------------------------------
+// Anthropic adapter
+// ---------------------------------------------------------------------------
+
+describe('AnthropicToolCallingProvider', () => {
+  function makeClient(mockCreate: jest.Mock) {
+    jest.doMock('@anthropic-ai/sdk', () => ({
+      __esModule: true,
+      default: class { messages = { create: mockCreate }; },
+    }), { virtual: true });
+    return new AnthropicToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with input_schema', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'healthy' }],
+    });
+    const provider = makeClient(mockCreate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.tools[0]).toMatchObject({
+      name: 'lisa_health',
+      description: 'Check server health',
+      input_schema: TOOL.parameters,
+    });
+  });
+
+  it('parses tool_use content block', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'tu_123', name: 'lisa_health', input: { verbose: true } }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0]).toEqual({ id: 'tu_123', name: 'lisa_health', args: { verbose: true } });
+    expect(res.content).toBeUndefined();
+  });
+
+  it('returns text content when no tool calls', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'all good' }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.content).toBe('all good');
+    expect(res.toolCalls).toBeUndefined();
+  });
+
+  it('formats second-turn tool result as user message with tool_result block', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
+    const provider = makeClient(mockCreate);
+
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'tu_123', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'tu_123', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const formatted = mockCreate.mock.calls[0][0].messages;
+    const toolResultMsg = formatted.find((m: any) => Array.isArray(m.content) && m.content[0]?.type === 'tool_result');
+    expect(toolResultMsg).toBeDefined();
+    expect(toolResultMsg.content[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'tu_123', content: 'ok' });
+  });
+
+  it('handles malformed JSON args gracefully', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'lisa_health', input: 'not-json' }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI adapter
+// ---------------------------------------------------------------------------
+
+describe('OpenAIToolCallingProvider', () => {
+  function makeClient(mockCreate: jest.Mock) {
+    jest.doMock('openai', () => ({
+      __esModule: true,
+      default: class { chat = { completions: { create: mockCreate } }; },
+    }), { virtual: true });
+    return new OpenAIToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with type:function wrapper', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: 'ok', tool_calls: [] } }],
+    });
+    const provider = makeClient(mockCreate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.tools[0]).toMatchObject({
+      type: 'function',
+      function: { name: 'lisa_health', description: 'Check server health', parameters: TOOL.parameters },
+    });
+  });
+
+  it('parses tool_calls from response', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_abc', function: { name: 'lisa_health', arguments: '{"verbose":true}' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0]).toEqual({ id: 'call_abc', name: 'lisa_health', args: { verbose: true } });
+    expect(res.content).toBeUndefined();
+  });
+
+  it('handles null content on tool-only response', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_1', function: { name: 'lisa_health', arguments: '{}' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.content).toBeUndefined();
+    expect(res.toolCalls).toHaveLength(1);
+  });
+
+  it('formats second-turn tool result as role:tool message with tool_call_id', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({ choices: [{ message: { content: 'done' } }] });
+    const provider = makeClient(mockCreate);
+
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'call_abc', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'call_abc', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const formatted = mockCreate.mock.calls[0][0].messages;
+    const toolMsg = formatted.find((m: any) => m.role === 'tool');
+    expect(toolMsg).toMatchObject({ role: 'tool', tool_call_id: 'call_abc', content: 'ok' });
+  });
+
+  it('handles malformed JSON args gracefully', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_1', function: { name: 'lisa_health', arguments: 'not-json' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini adapter
+// ---------------------------------------------------------------------------
+
+describe('GeminiToolCallingProvider', () => {
+  function makeClient(mockGenerate: jest.Mock) {
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return { generateContent: mockGenerate };
+        }
+      },
+    }), { virtual: true });
+    return new GeminiToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with functionDeclarations (camelCase)', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }], text: () => 'ok' },
+    });
+    const provider = makeClient(mockGenerate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockGenerate.mock.calls[0][0];
+    // Tools go to getGenerativeModel(), NOT to generateContent() — verify absence here
+    expect(call).not.toHaveProperty('functionDeclarations');
+    expect(call).not.toHaveProperty('function_declarations');
+  });
+
+  it('passes functionDeclarations to getGenerativeModel', async () => {
+    let capturedConfig: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel(config: any) {
+          capturedConfig = config;
+          return { generateContent: jest.fn().mockResolvedValue({
+            response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+          }) };
+        }
+      },
+    }), { virtual: true });
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(capturedConfig.tools[0]).toHaveProperty('functionDeclarations');
+    expect(capturedConfig.tools[0].functionDeclarations[0]).toMatchObject({
+      name: 'lisa_health',
+      description: 'Check server health',
+    });
+  });
+
+  it('parses functionCall parts from response', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: {
+        candidates: [{ content: { parts: [
+          { functionCall: { name: 'lisa_health', args: { verbose: true } } },
+        ] } }],
+      },
+    });
+    const provider = makeClient(mockGenerate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0].name).toBe('lisa_health');
+    expect(res.toolCalls![0].args).toEqual({ verbose: true });
+    expect(res.toolCalls![0].id).toMatch(/gemini-call-/);
+  });
+
+  it('formats second-turn tool result as functionResponse part', async () => {
+    let capturedContents: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return {
+            generateContent: jest.fn().mockImplementation(({ contents }: any) => {
+              capturedContents = contents;
+              return Promise.resolve({ response: { candidates: [{ content: { parts: [{ text: 'done' }] } }] } });
+            }),
+          };
+        }
+      },
+    }), { virtual: true });
+
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'gemini-call-0', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'gemini-call-0', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const toolResultTurn = capturedContents.find((c: any) =>
+      c.parts?.some((p: any) => p.functionResponse),
+    );
+    expect(toolResultTurn).toBeDefined();
+    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({ response: { content: 'ok' } });
+  });
+
+  it('handles malformed args gracefully', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: {
+        candidates: [{ content: { parts: [
+          { functionCall: { name: 'lisa_health', args: 'bad' } },
+        ] } }],
+      },
+    });
+    const provider = makeClient(mockGenerate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider factory
+// ---------------------------------------------------------------------------
+
+describe('resolveToolCallingProvider()', () => {
+  const ORIG = process.env['LISA_LLM_PROVIDER'];
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env['LISA_LLM_PROVIDER'];
+    else process.env['LISA_LLM_PROVIDER'] = ORIG;
+  });
+
+  it('returns undefined when LISA_LLM_PROVIDER is unset', () => {
+    delete process.env['LISA_LLM_PROVIDER'];
+    expect(resolveToolCallingProvider()).toBeUndefined();
+  });
+
+  it('returns AnthropicToolCallingProvider for "anthropic"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'anthropic';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(AnthropicToolCallingProvider);
+  });
+
+  it('returns AnthropicToolCallingProvider for "claude"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'claude';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(AnthropicToolCallingProvider);
+  });
+
+  it('returns OpenAIToolCallingProvider for "openai"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'openai';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(OpenAIToolCallingProvider);
+  });
+
+  it('returns GeminiToolCallingProvider for "gemini"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'gemini';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(GeminiToolCallingProvider);
+  });
+
+  it('throws for unknown provider', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'llama';
+    expect(() => resolveToolCallingProvider()).toThrow(/Unknown LISA_LLM_PROVIDER/);
+  });
+});

--- a/src/llm-providers/llm-providers.test.ts
+++ b/src/llm-providers/llm-providers.test.ts
@@ -279,7 +279,41 @@ describe('GeminiToolCallingProvider', () => {
       c.parts?.some((p: any) => p.functionResponse),
     );
     expect(toolResultTurn).toBeDefined();
-    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({ response: { content: 'ok' } });
+    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({
+      name: 'lisa_health',      // must be tool name, NOT synthetic ID (gemini-call-0)
+      response: { content: 'ok' },
+    });
+  });
+
+  it('functionResponse.name resolves to tool name, not synthetic call id', async () => {
+    // Adapter-level round-trip: messages carry the same synthetic ID (gemini-call-0) that
+    // AgentLoopProvider produces. formatMessages() must resolve it back to the function name.
+    let capturedContents: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return {
+            generateContent: jest.fn().mockImplementation(({ contents }: any) => {
+              capturedContents = contents;
+              return Promise.resolve({ response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] } });
+            }),
+          };
+        }
+      },
+    }), { virtual: true });
+
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'gemini-call-0', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'gemini-call-0', content: 'healthy' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const toolResultTurn = capturedContents.find((c: any) =>
+      c.parts?.some((p: any) => p.functionResponse),
+    );
+    expect(toolResultTurn.parts[0].functionResponse.name).toBe('lisa_health');
   });
 
   it('handles malformed args gracefully', async () => {

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -1,0 +1,85 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class OpenAIToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'gpt-4o', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `openai-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['OPENAI_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('openai' as string).catch(() => {
+      throw new Error('OpenAIToolCallingProvider requires openai');
+    }) as { default: new (opts: { apiKey: string }) => any };
+
+    const client = new mod.default({ apiKey: this.apiKey });
+
+    const response = await client.chat.completions.create({
+      model: this.model,
+      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+      ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+      tools: tools.map(t => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        },
+      })),
+      messages: this.formatMessages(messages),
+    }) as { choices: Array<{ message?: { content?: string | null; tool_calls?: Array<{ id: string; function: { name: string; arguments: string } }> } }> };
+
+    const msg = response.choices[0]?.message;
+    if (!msg) return {};
+
+    const toolCalls = (msg.tool_calls ?? []).map(tc => ({
+      id: tc.id,
+      name: tc.function.name,
+      args: this.safeParseArgs(tc.function.arguments),
+    }));
+
+    return {
+      // content may be null on tool-only responses — treat as absent
+      ...(msg.content ? { content: msg.content } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Each tool result is a separate tool message
+        for (const r of msg.toolResults) {
+          result.push({ role: 'tool', tool_call_id: r.toolCallId, content: r.content });
+        }
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'assistant',
+          content: msg.content ?? null,
+          tool_calls: msg.toolCalls.map(tc => ({
+            id: tc.id,
+            type: 'function',
+            function: { name: tc.name, arguments: JSON.stringify(tc.args) },
+          })),
+        });
+      } else {
+        result.push({ role: msg.role, content: msg.content ?? '' });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(args: string): Record<string, unknown> {
+    try { return JSON.parse(args); } catch { return {}; }
+  }
+}

--- a/src/llm-providers/types.ts
+++ b/src/llm-providers/types.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Tool-calling types — separate from the existing LlmProvider.complete() path
+// ---------------------------------------------------------------------------
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>; // JSON Schema object
+}
+
+export interface ToolCall {
+  id: string; // required — must be preserved into ToolResult for second-turn correlation
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolResult {
+  toolCallId: string;
+  content: string;
+}
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content?: string;
+  toolCalls?: ToolCall[];   // populated on assistant messages when model requests tools
+  toolResults?: ToolResult[]; // populated on user messages returning tool results
+}
+
+export interface ChatResponse {
+  content?: string;
+  toolCalls?: ToolCall[];
+}
+
+export interface ChatOptions {
+  temperature?: number;
+  maxTokens?: number;
+}
+
+/**
+ * Tool-calling LLM provider interface.
+ * Separate from LlmProvider.complete() — for models that support structured tool calls.
+ */
+export interface ToolCallingLlmProvider {
+  readonly id: string;
+  chat(params: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse>;
+}

--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -1,0 +1,270 @@
+import { McpClient, createMcpClient } from './mcp-client';
+import * as path from 'path';
+import { EventEmitter } from 'events';
+
+// ---------------------------------------------------------------------------
+// Mock child_process at module level so spawn is configurable
+// ---------------------------------------------------------------------------
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+import { spawn } from 'child_process';
+const mockSpawn = spawn as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Minimal mock binary process
+// ---------------------------------------------------------------------------
+
+interface MockProcess extends EventEmitter {
+  stdin: { write: jest.Mock };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: jest.Mock;
+}
+
+function makeMockProc(): MockProcess {
+  const proc = new EventEmitter() as MockProcess;
+  proc.stdin = { write: jest.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn(() => { proc.emit('close', 0); });
+  return proc;
+}
+
+/** Emit a JSON-RPC response on the mock process stdout. */
+function respond(proc: MockProcess, id: number, result: unknown): void {
+  proc.stdout.emit('data', Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n'));
+}
+
+/** Emit a JSON-RPC error on the mock process stdout. */
+function respondError(proc: MockProcess, id: number, message: string): void {
+  proc.stdout.emit('data', Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, error: { code: -1, message } }) + '\n'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('McpClient', () => {
+  let mockProc: MockProcess;
+
+  beforeEach(() => {
+    mockProc = makeMockProc();
+    mockSpawn.mockReturnValue(mockProc);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  // Helper: spawn client and auto-respond to initialize
+  async function spawnClient(opts?: { appUrl?: string; timeoutMs?: number }): Promise<McpClient> {
+    const client = new McpClient({
+      memoryDir: '/tmp/test-memory',
+      command: { cmd: 'lisa-mcp', args: [] },
+      ...opts,
+    });
+
+    const spawnPromise = client.spawn();
+    // initialize is id=1 — respond immediately
+    await new Promise(r => setImmediate(r));
+    respond(mockProc, 1, { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'lisa-mcp', version: '1.0.1' } });
+    await spawnPromise;
+    return client;
+  }
+
+  describe('spawn()', () => {
+    it('starts binary with LISA_MEMORY_DIR env', async () => {
+      await spawnClient();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'lisa-mcp',
+        [],
+        expect.objectContaining({
+          env: expect.objectContaining({ LISA_MEMORY_DIR: '/tmp/test-memory' }),
+        }),
+      );
+    });
+
+    it('passes LISA_APP_URL when provided', async () => {
+      await spawnClient({ appUrl: 'http://localhost:3000' });
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({ LISA_APP_URL: 'http://localhost:3000' }),
+        }),
+      );
+    });
+
+    it('sends initialize then notifications/initialized', async () => {
+      await spawnClient();
+      const calls: string[] = mockProc.stdin.write.mock.calls.map((c: any[]) => c[0] as string);
+      const initCall = calls.find(c => c.includes('"initialize"'));
+      const notifCall = calls.find(c => c.includes('notifications/initialized'));
+      expect(initCall).toBeDefined();
+      expect(JSON.parse(initCall!)).toMatchObject({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: { protocolVersion: '2024-11-05' },
+      });
+      expect(notifCall).toBeDefined();
+      // notification has no id
+      expect(JSON.parse(notifCall!)).not.toHaveProperty('id');
+    });
+  });
+
+  describe('getTools()', () => {
+    const REQUIRED_TOOLS = [
+      'lisa_health',
+      'lisa_explore',
+      'lisa_action',
+      'lisa_flow',
+      'lisa_run_flow',
+    ];
+
+    it('returns tool list including required tools', async () => {
+      const client = await spawnClient();
+
+      const toolsPromise = client.getTools();
+      await new Promise(r => setImmediate(r));
+      respond(mockProc, 2, {
+        tools: REQUIRED_TOOLS.map(name => ({
+          name,
+          description: `${name} tool`,
+          inputSchema: { type: 'object', properties: {} },
+        })),
+      });
+
+      const tools = await toolsPromise;
+      const names = tools.map(t => t.name);
+      for (const required of REQUIRED_TOOLS) {
+        expect(names).toContain(required);
+      }
+    });
+
+    it('throws on JSON-RPC error', async () => {
+      const client = await spawnClient();
+      const toolsPromise = client.getTools();
+      await new Promise(r => setImmediate(r));
+      respondError(mockProc, 2, 'server error');
+      await expect(toolsPromise).rejects.toThrow('tools/list failed: server error');
+    });
+  });
+
+  describe('callTool()', () => {
+    it('round-trips tool name and args', async () => {
+      const client = await spawnClient();
+      const callPromise = client.callTool('lisa_health', { verbose: true });
+      await new Promise(r => setImmediate(r));
+      const calls: string[] = mockProc.stdin.write.mock.calls.map((c: any[]) => c[0] as string);
+      const toolCall = calls.find(c => c.includes('tools/call'));
+      expect(JSON.parse(toolCall!)).toMatchObject({
+        method: 'tools/call',
+        params: { name: 'lisa_health', arguments: { verbose: true } },
+      });
+      respond(mockProc, 2, { content: [{ type: 'text', text: 'ok' }] });
+      const result = await callPromise;
+      expect(result.content[0].text).toBe('ok');
+    });
+
+    it('throws on tool execution error', async () => {
+      const client = await spawnClient();
+      const callPromise = client.callTool('lisa_health', {});
+      await new Promise(r => setImmediate(r));
+      respondError(mockProc, 2, 'tool failed');
+      await expect(callPromise).rejects.toThrow('tools/call lisa_health failed: tool failed');
+    });
+  });
+
+  describe('non-JSON stdout tolerance', () => {
+    it('ignores non-JSON log lines without throwing', async () => {
+      const client = new McpClient({
+        memoryDir: '/tmp/test-memory',
+        command: { cmd: 'lisa-mcp', args: [] },
+      });
+
+      const spawnPromise = client.spawn();
+      // Emit a non-JSON log line before the response
+      mockProc.stdout.emit('data', Buffer.from('[MemoryService] Loaded 0 memories\n'));
+      await new Promise(r => setImmediate(r));
+      respond(mockProc, 1, { protocolVersion: '2024-11-05', capabilities: {} });
+      await expect(spawnPromise).resolves.toBeUndefined();
+    });
+
+    it('handles mixed JSON and non-JSON in same chunk', async () => {
+      const client = await spawnClient();
+      const toolsPromise = client.getTools();
+      await new Promise(r => setImmediate(r));
+
+      const mixed = '[MemoryService] info\n' + JSON.stringify({
+        jsonrpc: '2.0', id: 2,
+        result: { tools: [{ name: 'lisa_health', description: '', inputSchema: {} }] },
+      }) + '\n';
+      mockProc.stdout.emit('data', Buffer.from(mixed));
+
+      const tools = await toolsPromise;
+      expect(tools[0].name).toBe('lisa_health');
+    });
+  });
+
+  describe('close()', () => {
+    it('kills the process', async () => {
+      const client = await spawnClient();
+      client.close();
+      expect(mockProc.kill).toHaveBeenCalled();
+    });
+
+    it('rejects pending requests on close', async () => {
+      const client = await spawnClient();
+      const callPromise = client.callTool('lisa_health', {});
+      await new Promise(r => setImmediate(r));
+      client.close();
+      await expect(callPromise).rejects.toThrow('McpClient closed');
+    });
+  });
+
+  describe('timeout', () => {
+    it('rejects and kills process on timeout', async () => {
+      const client = new McpClient({
+        memoryDir: '/tmp/test-memory',
+        command: { cmd: 'lisa-mcp', args: [] },
+        timeoutMs: 50, // real timer — fast enough for a unit test
+      });
+      // Never respond to initialize → times out
+      await expect(client.spawn()).rejects.toThrow(/timed out/);
+    }, 2000);
+  });
+
+  describe('before spawn()', () => {
+    it('callTool rejects if not spawned', async () => {
+      const client = new McpClient({
+        memoryDir: '/tmp/test-memory',
+        command: { cmd: 'lisa-mcp', args: [] },
+      });
+      await expect(client.callTool('lisa_health', {})).rejects.toThrow('not spawned');
+    });
+  });
+
+  describe('createMcpClient()', () => {
+    it('resolves memoryDir from iterRoot', async () => {
+      const client = createMcpClient('/my/iter/root', { command: { cmd: 'test', args: [] } });
+      const spawnPromise = client.spawn();
+      await new Promise(r => setImmediate(r));
+      respond(mockProc, 1, { protocolVersion: '2024-11-05', capabilities: {} });
+      await spawnPromise;
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            LISA_MEMORY_DIR: path.join('/my/iter/root', '.lisa_memory'),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -222,7 +222,50 @@ describe('McpClient', () => {
       const callPromise = client.callTool('lisa_health', {});
       await new Promise(r => setImmediate(r));
       client.close();
-      await expect(callPromise).rejects.toThrow('McpClient closed');
+      await expect(callPromise).rejects.toThrow(/exited|killed/);
+    });
+  });
+
+  describe('process lifecycle failures', () => {
+    it('spawn() rejects when process emits error before initialize responds', async () => {
+      const client = new McpClient({
+        memoryDir: '/tmp/test-memory',
+        command: { cmd: 'lisa-mcp', args: [] },
+      });
+
+      const spawnPromise = client.spawn();
+      await new Promise(r => setImmediate(r));
+      // Emit process error before initialize responds
+      mockProc.emit('error', new Error('ENOENT: binary not found'));
+      await expect(spawnPromise).rejects.toThrow(/ENOENT|timed out/);
+    }, 2000);
+
+    it('spawn() rejects when initialize returns a JSON-RPC error', async () => {
+      const client = new McpClient({
+        memoryDir: '/tmp/test-memory',
+        command: { cmd: 'lisa-mcp', args: [] },
+      });
+
+      const spawnPromise = client.spawn();
+      await new Promise(r => setImmediate(r));
+      respondError(mockProc, 1, 'unsupported protocol version');
+      await expect(spawnPromise).rejects.toThrow('MCP initialize failed: unsupported protocol version');
+    });
+
+    it('in-flight callTool rejects immediately when process closes unexpectedly', async () => {
+      const client = await spawnClient();
+      const callPromise = client.callTool('lisa_health', {});
+      await new Promise(r => setImmediate(r));
+      // Process crashes mid-flight
+      mockProc.emit('close', 1, null);
+      await expect(callPromise).rejects.toThrow(/exited/);
+    });
+
+    it('subsequent callTool after crash rejects immediately', async () => {
+      const client = await spawnClient();
+      mockProc.emit('close', 1, null);
+      await new Promise(r => setImmediate(r));
+      await expect(client.callTool('lisa_health', {})).rejects.toThrow('not spawned');
     });
   });
 

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -1,0 +1,178 @@
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+
+export interface McpClientOptions {
+  /** Path to directory containing lisa.db — passed as LISA_MEMORY_DIR to binary. */
+  memoryDir: string;
+  /** Optional app URL passed as LISA_APP_URL to binary. */
+  appUrl?: string;
+  /** Override the binary command. Defaults to buildLisaMcpCommand() from @kaneshir/lisa-mcp. */
+  command?: { cmd: string; args: string[] };
+  /** Per-request timeout in ms. Default: 30_000. */
+  timeoutMs?: number;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpCallResult {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export class McpClient {
+  private readonly opts: Required<Pick<McpClientOptions, 'memoryDir' | 'timeoutMs'>> &
+    Pick<McpClientOptions, 'appUrl' | 'command'>;
+
+  private proc: ChildProcess | null = null;
+  private buf = '';
+  private nextId = 1;
+  private pending = new Map<number, (r: JsonRpcResponse) => void>();
+  private initialized = false;
+
+  constructor(opts: McpClientOptions) {
+    this.opts = {
+      memoryDir: opts.memoryDir,
+      appUrl: opts.appUrl,
+      command: opts.command,
+      timeoutMs: opts.timeoutMs ?? 30_000,
+    };
+  }
+
+  async spawn(): Promise<void> {
+    const { cmd, args } = await this.resolveCommand();
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      LISA_MEMORY_DIR: this.opts.memoryDir,
+    };
+    if (this.opts.appUrl) env.LISA_APP_URL = this.opts.appUrl;
+
+    this.proc = spawn(cmd, args, { env, stdio: ['pipe', 'pipe', 'pipe'] });
+
+    this.proc.stdout!.on('data', (chunk: Buffer) => {
+      this.buf += chunk.toString();
+      const lines = this.buf.split('\n');
+      this.buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let msg: JsonRpcResponse;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue; // non-JSON log lines from binary — ignore
+        }
+        if (msg.id != null && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+
+    this.proc.on('error', (err) => {
+      // Reject all pending requests
+      for (const resolve of this.pending.values()) {
+        resolve({ id: -1, error: { code: -1, message: err.message } });
+      }
+      this.pending.clear();
+    });
+
+    await this.initialize();
+  }
+
+  async getTools(): Promise<McpTool[]> {
+    const res = await this.call('tools/list', {});
+    if (res.error) throw new Error(`tools/list failed: ${res.error.message}`);
+    return (res.result as { tools: McpTool[] }).tools;
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpCallResult> {
+    const res = await this.call('tools/call', { name, arguments: args });
+    if (res.error) throw new Error(`tools/call ${name} failed: ${res.error.message}`);
+    return res.result as McpCallResult;
+  }
+
+  close(): void {
+    // Resolve all pending with a closed error so callers don't hang
+    for (const resolve of this.pending.values()) {
+      resolve({ id: -1, error: { code: -32000, message: 'McpClient closed' } });
+    }
+    this.pending.clear();
+    this.proc?.kill();
+    this.proc = null;
+    this.initialized = false;
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.initialized) return;
+    await this.call('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'stf-mcp-client', version: '1.0.0' },
+    });
+    // Notification — no response expected
+    this.send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
+    this.initialized = true;
+  }
+
+  private call(method: string, params: object): Promise<JsonRpcResponse> {
+    return new Promise((resolve, reject) => {
+      if (!this.proc) {
+        reject(new Error('McpClient not spawned — call spawn() first'));
+        return;
+      }
+
+      const id = this.nextId++;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        this.proc?.kill();
+        reject(new Error(`MCP request timed out: ${method} (${this.opts.timeoutMs}ms)`));
+      }, this.opts.timeoutMs);
+
+      this.pending.set(id, (res) => {
+        clearTimeout(timer);
+        resolve(res);
+      });
+
+      this.send({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  private send(obj: object): void {
+    this.proc?.stdin?.write(JSON.stringify(obj) + '\n');
+  }
+
+  private async resolveCommand(): Promise<{ cmd: string; args: string[] }> {
+    if (this.opts.command) return this.opts.command;
+    try {
+      const pkg = await import('@kaneshir/lisa-mcp') as { buildLisaMcpCommand(): { cmd: string; args: string[] } };
+      return pkg.buildLisaMcpCommand();
+    } catch {
+      throw new Error(
+        'lisa-mcp binary not found. Install @kaneshir/lisa-mcp or pass command to McpClient.',
+      );
+    }
+  }
+}
+
+/**
+ * Convenience factory — resolves memoryDir from iterRoot using the standard convention.
+ */
+export function createMcpClient(
+  iterRoot: string,
+  opts?: Omit<McpClientOptions, 'memoryDir'>,
+): McpClient {
+  return new McpClient({
+    ...opts,
+    memoryDir: path.join(iterRoot, '.lisa_memory'),
+  });
+}

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -79,11 +79,16 @@ export class McpClient {
     });
 
     this.proc.on('error', (err) => {
-      // Reject all pending requests
-      for (const resolve of this.pending.values()) {
-        resolve({ id: -1, error: { code: -1, message: err.message } });
-      }
-      this.pending.clear();
+      this.rejectAll(`Process error: ${err.message}`);
+    });
+
+    this.proc.on('close', (code, signal) => {
+      const msg = signal
+        ? `lisa-mcp process killed (signal: ${signal})`
+        : `lisa-mcp process exited (code: ${code})`;
+      this.rejectAll(msg);
+      this.proc = null;
+      this.initialized = false;
     });
 
     await this.initialize();
@@ -102,23 +107,27 @@ export class McpClient {
   }
 
   close(): void {
-    // Resolve all pending with a closed error so callers don't hang
+    this.proc?.kill();
+    // close event will fire and call rejectAll + clear state
+  }
+
+  private rejectAll(message: string): void {
     for (const resolve of this.pending.values()) {
-      resolve({ id: -1, error: { code: -32000, message: 'McpClient closed' } });
+      resolve({ id: -1, error: { code: -32000, message } });
     }
     this.pending.clear();
-    this.proc?.kill();
-    this.proc = null;
-    this.initialized = false;
   }
 
   private async initialize(): Promise<void> {
     if (this.initialized) return;
-    await this.call('initialize', {
+    const res = await this.call('initialize', {
       protocolVersion: '2024-11-05',
       capabilities: {},
       clientInfo: { name: 'stf-mcp-client', version: '1.0.0' },
     });
+    if (res.error) {
+      throw new Error(`MCP initialize failed: ${res.error.message}`);
+    }
     // Notification — no response expected
     this.send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
     this.initialized = true;


### PR DESCRIPTION
## Summary

- Adds `ToolCallingLlmProvider` interface (`types.ts`) with canonical `Message`, `ToolDefinition`, `ToolCall`, `ToolResult`, `ChatResponse` types
- `AnthropicToolCallingProvider` — `input_schema` tool format, `tool_use` block parsing, `tool_result` second-turn
- `OpenAIToolCallingProvider` — `type:function` wrapper, `tool_calls` parsing, null-content handling, `role:tool` second-turn
- `GeminiToolCallingProvider` — camelCase `functionDeclarations`, `functionCall` part parsing, positional call IDs (`gemini-call-N`), `functionResponse` second-turn
- `resolveToolCallingProvider()` reads `LISA_LLM_PROVIDER` env var; returns `undefined` when unset so the existing Claude CLI path is untouched

Closes #5

## Test plan

- [x] 21 unit tests — tool format round-trips, response parsing, second-turn wire shapes, malformed-arg graceful fallback, factory env resolution
- [x] All 21 passing (`npx jest llm-providers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)