### PR TITLE
chore: sync main → develop (STF #5 + #6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/src/agent-loop.test.ts
+++ b/src/agent-loop.test.ts
@@ -1,6 +1,10 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
 import { AgentLoopProvider } from './agent-loop';
+import { McpClient } from './mcp-client';
 import type { ToolCallingLlmProvider, ChatResponse, Message, ToolDefinition } from './llm-providers/types';
-import type { McpClient, McpTool } from './mcp-client';
+import type { McpTool } from './mcp-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -242,4 +246,75 @@ describe('resolveProvider() with LISA_LLM_PROVIDER', () => {
       expect(provider).not.toBeInstanceOf(AgentLoopProvider);
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real McpClient binary + mock ToolCallingLlmProvider
+// ---------------------------------------------------------------------------
+
+describe('AgentLoopProvider — integration (real McpClient)', () => {
+  let memoryDir: string;
+
+  beforeEach(() => {
+    memoryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stf-agent-loop-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(memoryDir, { recursive: true, force: true });
+  });
+
+  it(
+    'spawns lisa-mcp binary, calls lisa_health, returns final text',
+    async () => {
+      const client = new McpClient({ memoryDir });
+
+      // Mock provider: first turn calls lisa_health, second returns text
+      let turn = 0;
+      const toolProvider: ToolCallingLlmProvider = {
+        id: 'mock-integration',
+        chat: jest.fn().mockImplementation(async ({ tools }: { tools: ToolDefinition[]; messages: Message[] }) => {
+          turn++;
+          if (turn === 1) {
+            // Verify real tools arrived from binary
+            const health = tools.find(t => t.name === 'lisa_health');
+            expect(health).toBeDefined();
+            return {
+              toolCalls: [{ id: 'int-1', name: 'lisa_health', args: {} }],
+            } as ChatResponse;
+          }
+          return { content: 'integration passed' } as ChatResponse;
+        }),
+      };
+
+      const loop = new AgentLoopProvider(toolProvider, client);
+      const result = await loop.complete('check health');
+
+      expect(result).toBe('integration passed');
+      expect(turn).toBe(2);
+
+      const chatMock = toolProvider.chat as jest.Mock;
+      // Second chat call should carry the tool result from lisa_health
+      const secondMessages: Message[] = chatMock.mock.calls[1][0].messages;
+      const toolResultTurn = secondMessages.find(m => m.toolResults);
+      expect(toolResultTurn).toBeDefined();
+      expect(toolResultTurn!.toolResults![0].toolCallId).toBe('int-1');
+    },
+    15_000, // binary cold start can be slow
+  );
+
+  it(
+    'closes the binary process in finally when provider throws',
+    async () => {
+      const client = new McpClient({ memoryDir });
+      const toolProvider: ToolCallingLlmProvider = {
+        id: 'mock-error',
+        chat: jest.fn().mockRejectedValue(new Error('provider down')),
+      };
+      const loop = new AgentLoopProvider(toolProvider, client);
+      await expect(loop.complete('fail')).rejects.toThrow('provider down');
+      // If close() wasn't called, the process would linger and the test would
+      // hang — Jest's open-handles detection catches this.
+    },
+    15_000,
+  );
 });

--- a/src/agent-loop.test.ts
+++ b/src/agent-loop.test.ts
@@ -1,0 +1,245 @@
+import { AgentLoopProvider } from './agent-loop';
+import type { ToolCallingLlmProvider, ChatResponse, Message, ToolDefinition } from './llm-providers/types';
+import type { McpClient, McpTool } from './mcp-client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TOOLS: McpTool[] = [
+  { name: 'lisa_health', description: 'Check health', inputSchema: { type: 'object', properties: {} } },
+  { name: 'lisa_navigate', description: 'Navigate app', inputSchema: { type: 'object', properties: { url: { type: 'string' } } } },
+];
+
+function makeMcpClient(overrides: Partial<{
+  spawn: jest.Mock;
+  getTools: jest.Mock;
+  callTool: jest.Mock;
+  close: jest.Mock;
+}> = {}): McpClient {
+  return {
+    spawn: overrides.spawn ?? jest.fn().mockResolvedValue(undefined),
+    getTools: overrides.getTools ?? jest.fn().mockResolvedValue(TOOLS),
+    callTool: overrides.callTool ?? jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+    close: overrides.close ?? jest.fn(),
+  } as unknown as McpClient;
+}
+
+function makeChatProvider(responses: ChatResponse[]): ToolCallingLlmProvider {
+  let i = 0;
+  return {
+    id: 'mock-provider',
+    chat: jest.fn().mockImplementation(async () => responses[Math.min(i++, responses.length - 1)]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AgentLoopProvider — core loop behaviour
+// ---------------------------------------------------------------------------
+
+describe('AgentLoopProvider', () => {
+  it('returns text response when no tool calls', async () => {
+    const client = makeMcpClient();
+    const provider = makeChatProvider([{ content: 'all good' }]);
+    const loop = new AgentLoopProvider(provider, client);
+    const result = await loop.complete('check health');
+    expect(result).toBe('all good');
+  });
+
+  it('has id prefixed with agent-loop:', () => {
+    const client = makeMcpClient();
+    const provider = { id: 'anthropic-tool:claude-sonnet-4-6', chat: jest.fn() } as unknown as ToolCallingLlmProvider;
+    const loop = new AgentLoopProvider(provider, client);
+    expect(loop.id).toBe('agent-loop:anthropic-tool:claude-sonnet-4-6');
+  });
+
+  it('happy path: tool call → result injected → final response', async () => {
+    const callTool = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'healthy' }] });
+    const client = makeMcpClient({ callTool });
+    const provider = makeChatProvider([
+      { toolCalls: [{ id: 'tc-1', name: 'lisa_health', args: {} }] },
+      { content: 'done' },
+    ]);
+    const loop = new AgentLoopProvider(provider, client);
+    const result = await loop.complete('run health check');
+
+    expect(result).toBe('done');
+    expect(callTool).toHaveBeenCalledWith('lisa_health', {});
+
+    const chatMock = provider.chat as jest.Mock;
+    const secondCall: { messages: Message[] } = chatMock.mock.calls[1][0];
+    const toolResultMsg = secondCall.messages.find(m => m.toolResults);
+    expect(toolResultMsg?.toolResults?.[0]).toMatchObject({ toolCallId: 'tc-1', content: 'healthy' });
+  });
+
+  it('multi-turn: two sequential tool calls before final response', async () => {
+    const callTool = jest.fn()
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'nav-result' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'health-result' }] });
+
+    const client = makeMcpClient({ callTool });
+    const provider = makeChatProvider([
+      { toolCalls: [{ id: 'tc-1', name: 'lisa_navigate', args: { url: '/home' } }] },
+      { toolCalls: [{ id: 'tc-2', name: 'lisa_health', args: {} }] },
+      { content: 'all flows passed' },
+    ]);
+    const loop = new AgentLoopProvider(provider, client);
+    const result = await loop.complete('test the app');
+
+    expect(result).toBe('all flows passed');
+    expect(callTool).toHaveBeenCalledTimes(2);
+    expect(callTool.mock.calls[0]).toEqual(['lisa_navigate', { url: '/home' }]);
+    expect(callTool.mock.calls[1]).toEqual(['lisa_health', {}]);
+  });
+
+  it('stops at maxIterations and returns last text seen', async () => {
+    const client = makeMcpClient();
+    let turn = 0;
+    const provider: ToolCallingLlmProvider = {
+      id: 'mock',
+      chat: jest.fn().mockImplementation(async () => {
+        turn++;
+        return turn === 1
+          ? { content: 'partial', toolCalls: [{ id: `tc-${turn}`, name: 'lisa_health', args: {} }] }
+          : { toolCalls: [{ id: `tc-${turn}`, name: 'lisa_health', args: {} }] };
+      }),
+    };
+    const loop = new AgentLoopProvider(provider, client, { maxIterations: 3 });
+    const result = await loop.complete('run');
+
+    expect(result).toBe('partial');
+    expect((provider.chat as jest.Mock).mock.calls).toHaveLength(3);
+  });
+
+  it('injects tool error as result string and continues loop', async () => {
+    const callTool = jest.fn().mockRejectedValue(new Error('tool timed out'));
+    const client = makeMcpClient({ callTool });
+    const provider = makeChatProvider([
+      { toolCalls: [{ id: 'tc-err', name: 'lisa_health', args: {} }] },
+      { content: 'recovered' },
+    ]);
+    const loop = new AgentLoopProvider(provider, client);
+    const result = await loop.complete('check');
+
+    expect(result).toBe('recovered');
+    const chatMock = provider.chat as jest.Mock;
+    const secondCall: { messages: Message[] } = chatMock.mock.calls[1][0];
+    const toolResultMsg = secondCall.messages.find(m => m.toolResults);
+    expect(toolResultMsg?.toolResults?.[0].content).toMatch(/Error: tool timed out/);
+  });
+
+  it('calls mcpClient.close() in finally even when chat throws', async () => {
+    const close = jest.fn();
+    const client = makeMcpClient({ close });
+    const provider: ToolCallingLlmProvider = {
+      id: 'mock',
+      chat: jest.fn().mockRejectedValue(new Error('LLM unavailable')),
+    };
+    const loop = new AgentLoopProvider(provider, client);
+    await expect(loop.complete('check')).rejects.toThrow('LLM unavailable');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls mcpClient.close() in finally on normal completion', async () => {
+    const close = jest.fn();
+    const client = makeMcpClient({ close });
+    const provider = makeChatProvider([{ content: 'ok' }]);
+    const loop = new AgentLoopProvider(provider, client);
+    await loop.complete('ping');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes tool definitions to chat() derived from getTools()', async () => {
+    const client = makeMcpClient();
+    const provider = makeChatProvider([{ content: 'done' }]);
+    const loop = new AgentLoopProvider(provider, client);
+    await loop.complete('go');
+
+    const chatMock = provider.chat as jest.Mock;
+    const calledTools: ToolDefinition[] = chatMock.mock.calls[0][0].tools;
+    expect(calledTools).toHaveLength(2);
+    expect(calledTools[0]).toMatchObject({ name: 'lisa_health', description: 'Check health' });
+    expect(calledTools[0].parameters).toEqual(TOOLS[0].inputSchema);
+  });
+
+  it('concatenates multiple text parts from callTool result', async () => {
+    const callTool = jest.fn().mockResolvedValue({
+      content: [
+        { type: 'text', text: 'part1' },
+        { type: 'image', text: undefined },
+        { type: 'text', text: 'part2' },
+      ],
+    });
+    const client = makeMcpClient({ callTool });
+    const provider = makeChatProvider([
+      { toolCalls: [{ id: 'tc-1', name: 'lisa_health', args: {} }] },
+      { content: 'ok' },
+    ]);
+    const loop = new AgentLoopProvider(provider, client);
+    await loop.complete('go');
+
+    const chatMock = provider.chat as jest.Mock;
+    const secondCall: { messages: Message[] } = chatMock.mock.calls[1][0];
+    const toolResult = secondCall.messages.find(m => m.toolResults)?.toolResults?.[0];
+    expect(toolResult?.content).toBe('part1\npart2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveProvider() — LISA_LLM_PROVIDER selection
+// ---------------------------------------------------------------------------
+
+describe('resolveProvider() with LISA_LLM_PROVIDER', () => {
+  const ORIG = process.env['LISA_LLM_PROVIDER'];
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env['LISA_LLM_PROVIDER'];
+    else process.env['LISA_LLM_PROVIDER'] = ORIG;
+    jest.resetModules();
+  });
+
+  it('returns AgentLoopProvider when LISA_LLM_PROVIDER=anthropic', async () => {
+    process.env['LISA_LLM_PROVIDER'] = 'anthropic';
+    const { resolveProvider } = await import('./llm-provider');
+    const provider = resolveProvider(undefined, undefined);
+    expect(provider).toBeInstanceOf(AgentLoopProvider);
+    expect(provider!.id).toMatch(/^agent-loop:anthropic-tool:/);
+  });
+
+  it('returns AgentLoopProvider when LISA_LLM_PROVIDER=openai', async () => {
+    process.env['LISA_LLM_PROVIDER'] = 'openai';
+    const { resolveProvider } = await import('./llm-provider');
+    const { AgentLoopProvider: Fresh } = await import('./agent-loop');
+    const provider = resolveProvider(undefined, undefined);
+    expect(provider).toBeInstanceOf(Fresh);
+    expect(provider!.id).toMatch(/^agent-loop:openai-tool:/);
+  });
+
+  it('returns AgentLoopProvider when LISA_LLM_PROVIDER=gemini', async () => {
+    process.env['LISA_LLM_PROVIDER'] = 'gemini';
+    const { resolveProvider } = await import('./llm-provider');
+    const { AgentLoopProvider: Fresh } = await import('./agent-loop');
+    const provider = resolveProvider(undefined, undefined);
+    expect(provider).toBeInstanceOf(Fresh);
+    expect(provider!.id).toMatch(/^agent-loop:gemini-tool:/);
+  });
+
+  it('explicit llmProvider still wins over LISA_LLM_PROVIDER', async () => {
+    process.env['LISA_LLM_PROVIDER'] = 'anthropic';
+    const { resolveProvider, ClaudeCliProvider } = await import('./llm-provider');
+    const explicit = new ClaudeCliProvider();
+    const provider = resolveProvider(undefined, explicit);
+    expect(provider).toBe(explicit);
+  });
+
+  it('falls through to Claude CLI when LISA_LLM_PROVIDER is unset', async () => {
+    delete process.env['LISA_LLM_PROVIDER'];
+    // Ensure claude isn't available so we get undefined (not ClaudeCliProvider)
+    const { resolveProvider } = await import('./llm-provider');
+    // With no CLI and no API keys this should return undefined
+    const provider = resolveProvider(undefined, undefined);
+    // We can't guarantee claude is in PATH in test env — just verify it's NOT an AgentLoopProvider
+    if (provider) {
+      expect(provider).not.toBeInstanceOf(AgentLoopProvider);
+    }
+  });
+});

--- a/src/agent-loop.test.ts
+++ b/src/agent-loop.test.ts
@@ -45,7 +45,7 @@ describe('AgentLoopProvider', () => {
   it('returns text response when no tool calls', async () => {
     const client = makeMcpClient();
     const provider = makeChatProvider([{ content: 'all good' }]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     const result = await loop.complete('check health');
     expect(result).toBe('all good');
   });
@@ -53,8 +53,68 @@ describe('AgentLoopProvider', () => {
   it('has id prefixed with agent-loop:', () => {
     const client = makeMcpClient();
     const provider = { id: 'anthropic-tool:claude-sonnet-4-6', chat: jest.fn() } as unknown as ToolCallingLlmProvider;
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     expect(loop.id).toBe('agent-loop:anthropic-tool:claude-sonnet-4-6');
+  });
+
+  it('passes options (temperature, maxTokens) through to chat()', async () => {
+    const client = makeMcpClient();
+    const provider = makeChatProvider([{ content: 'ok' }]);
+    const loop = new AgentLoopProvider(provider, () => client);
+    await loop.complete('go', { temperature: 0.2, maxTokens: 512 });
+    const chatMock = provider.chat as jest.Mock;
+    expect(chatMock.mock.calls[0][0].options).toEqual({ temperature: 0.2, maxTokens: 512 });
+  });
+
+  it('creates a fresh McpClient per complete() call — no shared state', async () => {
+    const clients: ReturnType<typeof makeMcpClient>[] = [];
+    const factory = () => {
+      const c = makeMcpClient();
+      clients.push(c);
+      return c;
+    };
+    const provider = makeChatProvider([{ content: 'done' }]);
+    const loop = new AgentLoopProvider(provider, factory);
+
+    // Two sequential calls — each must get its own client and close it
+    await loop.complete('first');
+    await loop.complete('second');
+
+    expect(clients).toHaveLength(2);
+    expect(clients[0]).not.toBe(clients[1]);
+    expect(clients[0].close).toHaveBeenCalledTimes(1);
+    expect(clients[1].close).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent complete() calls each get an independent client', async () => {
+    const clients: ReturnType<typeof makeMcpClient>[] = [];
+    const factory = () => {
+      const c = makeMcpClient();
+      clients.push(c);
+      return c;
+    };
+    const provider = makeChatProvider([{ content: 'done' }]);
+    const loop = new AgentLoopProvider(provider, factory);
+
+    await Promise.all([loop.complete('a'), loop.complete('b')]);
+
+    expect(clients).toHaveLength(2);
+    expect(clients[0]).not.toBe(clients[1]);
+    for (const c of clients) {
+      expect(c.spawn).toHaveBeenCalledTimes(1);
+      expect(c.close).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('calls close() in finally when spawn() rejects', async () => {
+    const close = jest.fn();
+    const spawn = jest.fn().mockRejectedValue(new Error('binary not found'));
+    const client = makeMcpClient({ spawn, close });
+    const provider = makeChatProvider([{ content: 'ok' }]);
+    const loop = new AgentLoopProvider(provider, () => client);
+
+    await expect(loop.complete('go')).rejects.toThrow('binary not found');
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('happy path: tool call → result injected → final response', async () => {
@@ -64,7 +124,7 @@ describe('AgentLoopProvider', () => {
       { toolCalls: [{ id: 'tc-1', name: 'lisa_health', args: {} }] },
       { content: 'done' },
     ]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     const result = await loop.complete('run health check');
 
     expect(result).toBe('done');
@@ -87,7 +147,7 @@ describe('AgentLoopProvider', () => {
       { toolCalls: [{ id: 'tc-2', name: 'lisa_health', args: {} }] },
       { content: 'all flows passed' },
     ]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     const result = await loop.complete('test the app');
 
     expect(result).toBe('all flows passed');
@@ -108,7 +168,7 @@ describe('AgentLoopProvider', () => {
           : { toolCalls: [{ id: `tc-${turn}`, name: 'lisa_health', args: {} }] };
       }),
     };
-    const loop = new AgentLoopProvider(provider, client, { maxIterations: 3 });
+    const loop = new AgentLoopProvider(provider, () => client, { maxIterations: 3 });
     const result = await loop.complete('run');
 
     expect(result).toBe('partial');
@@ -122,7 +182,7 @@ describe('AgentLoopProvider', () => {
       { toolCalls: [{ id: 'tc-err', name: 'lisa_health', args: {} }] },
       { content: 'recovered' },
     ]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     const result = await loop.complete('check');
 
     expect(result).toBe('recovered');
@@ -139,7 +199,7 @@ describe('AgentLoopProvider', () => {
       id: 'mock',
       chat: jest.fn().mockRejectedValue(new Error('LLM unavailable')),
     };
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     await expect(loop.complete('check')).rejects.toThrow('LLM unavailable');
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -148,7 +208,7 @@ describe('AgentLoopProvider', () => {
     const close = jest.fn();
     const client = makeMcpClient({ close });
     const provider = makeChatProvider([{ content: 'ok' }]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     await loop.complete('ping');
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +216,7 @@ describe('AgentLoopProvider', () => {
   it('passes tool definitions to chat() derived from getTools()', async () => {
     const client = makeMcpClient();
     const provider = makeChatProvider([{ content: 'done' }]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     await loop.complete('go');
 
     const chatMock = provider.chat as jest.Mock;
@@ -179,7 +239,7 @@ describe('AgentLoopProvider', () => {
       { toolCalls: [{ id: 'tc-1', name: 'lisa_health', args: {} }] },
       { content: 'ok' },
     ]);
-    const loop = new AgentLoopProvider(provider, client);
+    const loop = new AgentLoopProvider(provider, () => client);
     await loop.complete('go');
 
     const chatMock = provider.chat as jest.Mock;
@@ -266,8 +326,6 @@ describe('AgentLoopProvider — integration (real McpClient)', () => {
   it(
     'spawns lisa-mcp binary, calls lisa_health, returns final text',
     async () => {
-      const client = new McpClient({ memoryDir });
-
       // Mock provider: first turn calls lisa_health, second returns text
       let turn = 0;
       const toolProvider: ToolCallingLlmProvider = {
@@ -286,7 +344,7 @@ describe('AgentLoopProvider — integration (real McpClient)', () => {
         }),
       };
 
-      const loop = new AgentLoopProvider(toolProvider, client);
+      const loop = new AgentLoopProvider(toolProvider, () => new McpClient({ memoryDir }));
       const result = await loop.complete('check health');
 
       expect(result).toBe('integration passed');
@@ -305,12 +363,11 @@ describe('AgentLoopProvider — integration (real McpClient)', () => {
   it(
     'closes the binary process in finally when provider throws',
     async () => {
-      const client = new McpClient({ memoryDir });
       const toolProvider: ToolCallingLlmProvider = {
         id: 'mock-error',
         chat: jest.fn().mockRejectedValue(new Error('provider down')),
       };
-      const loop = new AgentLoopProvider(toolProvider, client);
+      const loop = new AgentLoopProvider(toolProvider, () => new McpClient({ memoryDir }));
       await expect(loop.complete('fail')).rejects.toThrow('provider down');
       // If close() wasn't called, the process would linger and the test would
       // hang — Jest's open-handles detection catches this.

--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -1,0 +1,72 @@
+import type { LlmProvider } from './llm-provider';
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ToolResult } from './llm-providers/types';
+import type { McpClient, McpTool } from './mcp-client';
+
+export class AgentLoopProvider implements LlmProvider {
+  readonly id: string;
+  private readonly toolProvider: ToolCallingLlmProvider;
+  private readonly mcpClient: McpClient;
+  private readonly maxIterations: number;
+
+  constructor(
+    toolProvider: ToolCallingLlmProvider,
+    mcpClient: McpClient,
+    { maxIterations = 10 }: { maxIterations?: number } = {},
+  ) {
+    this.toolProvider = toolProvider;
+    this.mcpClient = mcpClient;
+    this.maxIterations = maxIterations;
+    this.id = `agent-loop:${toolProvider.id}`;
+  }
+
+  async complete(prompt: string): Promise<string> {
+    await this.mcpClient.spawn();
+
+    try {
+      const mcpTools: McpTool[] = await this.mcpClient.getTools();
+      const tools: ToolDefinition[] = mcpTools.map(t => ({
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      }));
+
+      const messages: Message[] = [{ role: 'user', content: prompt }];
+      let lastText = '';
+
+      for (let i = 0; i < this.maxIterations; i++) {
+        const response = await this.toolProvider.chat({ messages, tools });
+
+        if (!response.toolCalls || response.toolCalls.length === 0) {
+          return response.content ?? lastText;
+        }
+
+        if (response.content) lastText = response.content;
+        messages.push({ role: 'assistant', toolCalls: response.toolCalls });
+
+        const toolResults: ToolResult[] = [];
+        for (const tc of response.toolCalls) {
+          let content: string;
+          try {
+            const result = await this.mcpClient.callTool(
+              tc.name,
+              tc.args as Record<string, unknown>,
+            );
+            content = result.content
+              .filter(c => c.type === 'text')
+              .map(c => c.text ?? '')
+              .join('\n');
+          } catch (err) {
+            content = `Error: ${err instanceof Error ? err.message : String(err)}`;
+          }
+          toolResults.push({ toolCallId: tc.id, content });
+        }
+
+        messages.push({ role: 'user', toolResults });
+      }
+
+      return lastText || '[agent-loop: maxIterations reached without text response]';
+    } finally {
+      this.mcpClient.close();
+    }
+  }
+}

--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -5,25 +5,31 @@ import type { McpClient, McpTool } from './mcp-client';
 export class AgentLoopProvider implements LlmProvider {
   readonly id: string;
   private readonly toolProvider: ToolCallingLlmProvider;
-  private readonly mcpClient: McpClient;
+  private readonly mcpClientFactory: () => McpClient;
   private readonly maxIterations: number;
 
   constructor(
     toolProvider: ToolCallingLlmProvider,
-    mcpClient: McpClient,
+    mcpClientFactory: () => McpClient,
     { maxIterations = 10 }: { maxIterations?: number } = {},
   ) {
     this.toolProvider = toolProvider;
-    this.mcpClient = mcpClient;
+    this.mcpClientFactory = mcpClientFactory;
     this.maxIterations = maxIterations;
     this.id = `agent-loop:${toolProvider.id}`;
   }
 
-  async complete(prompt: string): Promise<string> {
-    await this.mcpClient.spawn();
-
+  async complete(
+    prompt: string,
+    options?: { temperature?: number; maxTokens?: number },
+  ): Promise<string> {
+    // Fresh client per call — each complete() owns its own process, buffer, and pending map.
+    const client = this.mcpClientFactory();
     try {
-      const mcpTools: McpTool[] = await this.mcpClient.getTools();
+      // spawn() is inside try so close() is called even if the initialize handshake fails.
+      await client.spawn();
+
+      const mcpTools: McpTool[] = await client.getTools();
       const tools: ToolDefinition[] = mcpTools.map(t => ({
         name: t.name,
         description: t.description,
@@ -34,7 +40,7 @@ export class AgentLoopProvider implements LlmProvider {
       let lastText = '';
 
       for (let i = 0; i < this.maxIterations; i++) {
-        const response = await this.toolProvider.chat({ messages, tools });
+        const response = await this.toolProvider.chat({ messages, tools, options });
 
         if (!response.toolCalls || response.toolCalls.length === 0) {
           return response.content ?? lastText;
@@ -47,7 +53,7 @@ export class AgentLoopProvider implements LlmProvider {
         for (const tc of response.toolCalls) {
           let content: string;
           try {
-            const result = await this.mcpClient.callTool(
+            const result = await client.callTool(
               tc.name,
               tc.args as Record<string, unknown>,
             );
@@ -66,7 +72,7 @@ export class AgentLoopProvider implements LlmProvider {
 
       return lastText || '[agent-loop: maxIterations reached without text response]';
     } finally {
-      this.mcpClient.close();
+      client.close();
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type {
 export { FabricOrchestrator } from './orchestrator';
 export type { OrchestratorOptions, OrchestratorAdapters } from './orchestrator';
 export type { LlmProvider } from './llm-provider';
+export { AgentLoopProvider } from './agent-loop';
 export {
   ClaudeCliProvider,
   ClaudeSdkProvider,

--- a/src/llm-provider.test.ts
+++ b/src/llm-provider.test.ts
@@ -56,6 +56,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   // Default: claude CLI not available (tests that need it override per-test)
   mockExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+  // Guard: a locally-set LISA_LLM_PROVIDER would cause resolveProvider() to return
+  // an AgentLoopProvider, breaking tests that expect ClaudeSdkProvider etc.
+  delete process.env['LISA_LLM_PROVIDER'];
 });
 
 // ---------------------------------------------------------------------------

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -272,7 +272,7 @@ export function resolveProvider(
     const memoryDir = iterRoot
       ? path.join(iterRoot, '.lisa_memory')
       : path.join(process.cwd(), '.stf', '.lisa_memory');
-    return new AgentLoopProvider(toolProvider, new McpClient({ memoryDir }));
+    return new AgentLoopProvider(toolProvider, () => new McpClient({ memoryDir }));
   }
 
   // 3. ollama: prefix

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -1,4 +1,8 @@
 import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { AgentLoopProvider } from './agent-loop';
+import { resolveToolCallingProvider } from './llm-providers';
+import { McpClient } from './mcp-client';
 
 // ---------------------------------------------------------------------------
 // Interface
@@ -241,54 +245,66 @@ export class OpenAIProvider implements LlmProvider {
  *
  * Resolution order:
  *  1. llmProvider option set → use directly
- *  2. flowModel starts with 'ollama:' → OllamaProvider
- *  3. flowModel set (any other string) → GeminiProvider (legacy compat)
- *  4. claude CLI in PATH and STF_DISABLE_CLAUDE_CLI unset → ClaudeCliProvider (new default)
- *  5. ANTHROPIC_API_KEY set → ClaudeSdkProvider
- *  6. OPENAI_API_KEY set → OpenAIProvider
- *  7. GEMINI_API_KEY set → GeminiProvider
- *  8. None → undefined (caller should skip generation)
+ *  2. LISA_LLM_PROVIDER env var → AgentLoopProvider (wraps ToolCallingLlmProvider + McpClient)
+ *  3. flowModel starts with 'ollama:' → OllamaProvider
+ *  4. flowModel set (any other string) → GeminiProvider (legacy compat)
+ *  5. claude CLI in PATH and STF_DISABLE_CLAUDE_CLI unset → ClaudeCliProvider (new default)
+ *  6. ANTHROPIC_API_KEY set → ClaudeSdkProvider
+ *  7. OPENAI_API_KEY set → OpenAIProvider
+ *  8. GEMINI_API_KEY set → GeminiProvider
+ *  9. None → undefined (caller should skip generation)
  *
- * Set STF_DISABLE_CLAUDE_CLI=1 to skip step 4 in CI environments where the
+ * Pass iterRoot to get a correctly scoped LISA_MEMORY_DIR for the agentic loop.
+ * Set STF_DISABLE_CLAUDE_CLI=1 to skip step 5 in CI environments where the
  * claude CLI is installed but you want API-key-based providers instead.
  */
 export function resolveProvider(
   flowModel: string | undefined,
   llmProvider: LlmProvider | undefined,
+  { iterRoot }: { iterRoot?: string } = {},
 ): LlmProvider | undefined {
   // 1. Explicit provider wins
   if (llmProvider) return llmProvider;
 
-  // 2. ollama: prefix
+  // 2. LISA_LLM_PROVIDER → AgentLoopProvider (tool-calling agentic loop via lisa-mcp)
+  const toolProvider = resolveToolCallingProvider();
+  if (toolProvider) {
+    const memoryDir = iterRoot
+      ? path.join(iterRoot, '.lisa_memory')
+      : path.join(process.cwd(), '.stf', '.lisa_memory');
+    return new AgentLoopProvider(toolProvider, new McpClient({ memoryDir }));
+  }
+
+  // 3. ollama: prefix
   if (flowModel?.startsWith('ollama:')) {
     return new OllamaProvider({ model: flowModel.slice(7) });
   }
 
-  // 3. Any other flowModel string → Gemini (legacy)
+  // 4. Any other flowModel string → Gemini (legacy)
   if (flowModel) {
     return new GeminiProvider({ model: flowModel });
   }
 
-  // 4. Claude CLI auto-detection
+  // 5. Claude CLI auto-detection
   if (!process.env['STF_DISABLE_CLAUDE_CLI'] && claudeCliAvailable()) {
     return new ClaudeCliProvider();
   }
 
-  // 5. Anthropic SDK
+  // 6. Anthropic SDK
   if (process.env['ANTHROPIC_API_KEY']) {
     return new ClaudeSdkProvider();
   }
 
-  // 6. OpenAI
+  // 7. OpenAI
   if (process.env['OPENAI_API_KEY']) {
     return new OpenAIProvider();
   }
 
-  // 7. Gemini
+  // 8. Gemini
   if (process.env['GEMINI_API_KEY']) {
     return new GeminiProvider();
   }
 
-  // 8. Nothing configured
+  // 9. Nothing configured
   return undefined;
 }

--- a/src/llm-providers/anthropic.ts
+++ b/src/llm-providers/anthropic.ts
@@ -1,0 +1,94 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class AnthropicToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'claude-sonnet-4-6', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `anthropic-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['ANTHROPIC_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('@anthropic-ai/sdk' as string).catch(() => {
+      throw new Error('AnthropicToolCallingProvider requires @anthropic-ai/sdk');
+    }) as { default: new (opts: { apiKey: string }) => any };
+
+    const client = new mod.default({ apiKey: this.apiKey });
+
+    const response = await client.messages.create({
+      model: this.model,
+      max_tokens: options.maxTokens ?? 4096,
+      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+      tools: tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.parameters,
+      })),
+      messages: this.formatMessages(messages),
+    }) as { content: Array<{ type: string; id?: string; name?: string; input?: unknown; text?: string }> };
+
+    const toolCalls = response.content
+      .filter(b => b.type === 'tool_use')
+      .map(b => ({
+        id: b.id!,
+        name: b.name!,
+        args: this.safeParseArgs(b.input),
+      }));
+
+    const text = response.content
+      .filter(b => b.type === 'text')
+      .map(b => b.text ?? '')
+      .join('');
+
+    return {
+      ...(text ? { content: text } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Tool results go in a user message as tool_result content blocks
+        result.push({
+          role: 'user',
+          content: msg.toolResults.map(r => ({
+            type: 'tool_result',
+            tool_use_id: r.toolCallId,
+            content: r.content,
+          })),
+        });
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'assistant',
+          content: msg.toolCalls.map(tc => ({
+            type: 'tool_use',
+            id: tc.id,
+            name: tc.name,
+            input: tc.args,
+          })),
+        });
+      } else {
+        result.push({ role: msg.role, content: msg.content ?? '' });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(input: unknown): Record<string, unknown> {
+    if (typeof input === 'object' && input !== null) return input as Record<string, unknown>;
+    if (typeof input === 'string') {
+      try { return JSON.parse(input); } catch { return {}; }
+    }
+    return {};
+  }
+}

--- a/src/llm-providers/gemini.ts
+++ b/src/llm-providers/gemini.ts
@@ -77,19 +77,27 @@ export class GeminiToolCallingProvider implements ToolCallingLlmProvider {
 
   private formatMessages(messages: Message[]): unknown[] {
     const result: unknown[] = [];
+    // Gemini's functionResponse.name must match the declared function name, not the
+    // synthetic ID (gemini-call-N). Populate this map when we see an assistant turn so
+    // the next user/tool-result turn can look up the real name.
+    const toolNameById = new Map<string, string>();
+
     for (const msg of messages) {
       if (msg.role === 'user' && msg.toolResults) {
-        // Tool results as functionResponse parts in a user turn
         result.push({
           role: 'user',
           parts: msg.toolResults.map(r => ({
             functionResponse: {
-              name: r.toolCallId, // Gemini matches by function name, not ID
+              name: toolNameById.get(r.toolCallId) ?? r.toolCallId,
               response: { content: r.content },
             },
           })),
         });
       } else if (msg.role === 'assistant' && msg.toolCalls) {
+        toolNameById.clear();
+        for (const tc of msg.toolCalls) {
+          toolNameById.set(tc.id, tc.name);
+        }
         result.push({
           role: 'model',
           parts: msg.toolCalls.map(tc => ({

--- a/src/llm-providers/gemini.ts
+++ b/src/llm-providers/gemini.ts
@@ -1,0 +1,116 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class GeminiToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'gemini-1.5-pro', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `gemini-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['GEMINI_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('@google/generative-ai' as string).catch(() => {
+      throw new Error('GeminiToolCallingProvider requires @google/generative-ai');
+    }) as { GoogleGenerativeAI: new (key: string) => any };
+
+    const client = new mod.GoogleGenerativeAI(this.apiKey);
+    const genConfig: Record<string, number> = {};
+    if (options.temperature !== undefined) genConfig['temperature'] = options.temperature;
+    if (options.maxTokens !== undefined) genConfig['maxOutputTokens'] = options.maxTokens;
+
+    const genModel = client.getGenerativeModel({
+      model: this.model,
+      ...(Object.keys(genConfig).length > 0 ? { generationConfig: genConfig } : {}),
+      tools: [{
+        // SDK uses camelCase functionDeclarations
+        functionDeclarations: tools.map(t => ({
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        })),
+      }],
+    });
+
+    const contents = this.formatMessages(messages);
+    const result = await genModel.generateContent({ contents }) as {
+      response: {
+        candidates?: Array<{
+          content?: {
+            parts?: Array<{
+              text?: string;
+              functionCall?: { name: string; args: unknown };
+            }>;
+          };
+        }>;
+        text(): string;
+      };
+    };
+
+    const parts = result.response.candidates?.[0]?.content?.parts ?? [];
+
+    const toolCalls = parts
+      .filter(p => p.functionCall)
+      .map((p, i) => ({
+        id: `gemini-call-${i}`,  // Gemini doesn't provide call IDs — generate positional ones
+        name: p.functionCall!.name,
+        args: this.safeParseArgs(p.functionCall!.args),
+      }));
+
+    const text = parts
+      .filter(p => p.text)
+      .map(p => p.text!)
+      .join('');
+
+    return {
+      ...(text ? { content: text } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Tool results as functionResponse parts in a user turn
+        result.push({
+          role: 'user',
+          parts: msg.toolResults.map(r => ({
+            functionResponse: {
+              name: r.toolCallId, // Gemini matches by function name, not ID
+              response: { content: r.content },
+            },
+          })),
+        });
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'model',
+          parts: msg.toolCalls.map(tc => ({
+            functionCall: { name: tc.name, args: tc.args },
+          })),
+        });
+      } else {
+        result.push({
+          role: msg.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text: msg.content ?? '' }],
+        });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(args: unknown): Record<string, unknown> {
+    if (typeof args === 'object' && args !== null) return args as Record<string, unknown>;
+    if (typeof args === 'string') {
+      try { return JSON.parse(args); } catch { return {}; }
+    }
+    return {};
+  }
+}

--- a/src/llm-providers/index.ts
+++ b/src/llm-providers/index.ts
@@ -1,0 +1,41 @@
+export type {
+  ToolDefinition,
+  ToolCall,
+  ToolResult,
+  Message,
+  ChatResponse,
+  ChatOptions,
+  ToolCallingLlmProvider,
+} from './types';
+export { AnthropicToolCallingProvider } from './anthropic';
+export { OpenAIToolCallingProvider } from './openai';
+export { GeminiToolCallingProvider } from './gemini';
+
+import type { ToolCallingLlmProvider } from './types';
+import { AnthropicToolCallingProvider } from './anthropic';
+import { OpenAIToolCallingProvider } from './openai';
+import { GeminiToolCallingProvider } from './gemini';
+
+/**
+ * Resolve a ToolCallingLlmProvider from LISA_LLM_PROVIDER env var.
+ * Returns undefined when LISA_LLM_PROVIDER is unset — caller falls back to
+ * the existing LlmProvider / Claude CLI default path.
+ */
+export function resolveToolCallingProvider(): ToolCallingLlmProvider | undefined {
+  const p = process.env['LISA_LLM_PROVIDER'];
+  if (!p) return undefined;
+
+  const lower = p.toLowerCase();
+  if (lower === 'anthropic' || lower === 'claude') {
+    return new AnthropicToolCallingProvider();
+  }
+  if (lower === 'openai') {
+    return new OpenAIToolCallingProvider();
+  }
+  if (lower === 'gemini') {
+    return new GeminiToolCallingProvider();
+  }
+  throw new Error(
+    `Unknown LISA_LLM_PROVIDER: "${p}". Valid values: anthropic, openai, gemini`,
+  );
+}

--- a/src/llm-providers/llm-providers.test.ts
+++ b/src/llm-providers/llm-providers.test.ts
@@ -1,0 +1,339 @@
+import { AnthropicToolCallingProvider } from './anthropic';
+import { OpenAIToolCallingProvider } from './openai';
+import { GeminiToolCallingProvider } from './gemini';
+import { resolveToolCallingProvider } from './index';
+import type { ToolDefinition, Message } from './types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TOOL: ToolDefinition = {
+  name: 'lisa_health',
+  description: 'Check server health',
+  parameters: { type: 'object', properties: { verbose: { type: 'boolean' } } },
+};
+
+const USER_MSG: Message = { role: 'user', content: 'Check health' };
+
+// ---------------------------------------------------------------------------
+// Anthropic adapter
+// ---------------------------------------------------------------------------
+
+describe('AnthropicToolCallingProvider', () => {
+  function makeClient(mockCreate: jest.Mock) {
+    jest.doMock('@anthropic-ai/sdk', () => ({
+      __esModule: true,
+      default: class { messages = { create: mockCreate }; },
+    }), { virtual: true });
+    return new AnthropicToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with input_schema', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'healthy' }],
+    });
+    const provider = makeClient(mockCreate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.tools[0]).toMatchObject({
+      name: 'lisa_health',
+      description: 'Check server health',
+      input_schema: TOOL.parameters,
+    });
+  });
+
+  it('parses tool_use content block', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'tu_123', name: 'lisa_health', input: { verbose: true } }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0]).toEqual({ id: 'tu_123', name: 'lisa_health', args: { verbose: true } });
+    expect(res.content).toBeUndefined();
+  });
+
+  it('returns text content when no tool calls', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'all good' }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.content).toBe('all good');
+    expect(res.toolCalls).toBeUndefined();
+  });
+
+  it('formats second-turn tool result as user message with tool_result block', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
+    const provider = makeClient(mockCreate);
+
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'tu_123', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'tu_123', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const formatted = mockCreate.mock.calls[0][0].messages;
+    const toolResultMsg = formatted.find((m: any) => Array.isArray(m.content) && m.content[0]?.type === 'tool_result');
+    expect(toolResultMsg).toBeDefined();
+    expect(toolResultMsg.content[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'tu_123', content: 'ok' });
+  });
+
+  it('handles malformed JSON args gracefully', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'lisa_health', input: 'not-json' }],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI adapter
+// ---------------------------------------------------------------------------
+
+describe('OpenAIToolCallingProvider', () => {
+  function makeClient(mockCreate: jest.Mock) {
+    jest.doMock('openai', () => ({
+      __esModule: true,
+      default: class { chat = { completions: { create: mockCreate } }; },
+    }), { virtual: true });
+    return new OpenAIToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with type:function wrapper', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: 'ok', tool_calls: [] } }],
+    });
+    const provider = makeClient(mockCreate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.tools[0]).toMatchObject({
+      type: 'function',
+      function: { name: 'lisa_health', description: 'Check server health', parameters: TOOL.parameters },
+    });
+  });
+
+  it('parses tool_calls from response', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_abc', function: { name: 'lisa_health', arguments: '{"verbose":true}' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0]).toEqual({ id: 'call_abc', name: 'lisa_health', args: { verbose: true } });
+    expect(res.content).toBeUndefined();
+  });
+
+  it('handles null content on tool-only response', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_1', function: { name: 'lisa_health', arguments: '{}' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.content).toBeUndefined();
+    expect(res.toolCalls).toHaveLength(1);
+  });
+
+  it('formats second-turn tool result as role:tool message with tool_call_id', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({ choices: [{ message: { content: 'done' } }] });
+    const provider = makeClient(mockCreate);
+
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'call_abc', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'call_abc', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const formatted = mockCreate.mock.calls[0][0].messages;
+    const toolMsg = formatted.find((m: any) => m.role === 'tool');
+    expect(toolMsg).toMatchObject({ role: 'tool', tool_call_id: 'call_abc', content: 'ok' });
+  });
+
+  it('handles malformed JSON args gracefully', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: {
+        content: null,
+        tool_calls: [{ id: 'call_1', function: { name: 'lisa_health', arguments: 'not-json' } }],
+      }}],
+    });
+    const provider = makeClient(mockCreate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini adapter
+// ---------------------------------------------------------------------------
+
+describe('GeminiToolCallingProvider', () => {
+  function makeClient(mockGenerate: jest.Mock) {
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return { generateContent: mockGenerate };
+        }
+      },
+    }), { virtual: true });
+    return new GeminiToolCallingProvider({ apiKey: 'test-key' });
+  }
+
+  afterEach(() => jest.resetModules());
+
+  it('formats tools with functionDeclarations (camelCase)', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }], text: () => 'ok' },
+    });
+    const provider = makeClient(mockGenerate);
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    const call = mockGenerate.mock.calls[0][0];
+    // Tools go to getGenerativeModel(), NOT to generateContent() — verify absence here
+    expect(call).not.toHaveProperty('functionDeclarations');
+    expect(call).not.toHaveProperty('function_declarations');
+  });
+
+  it('passes functionDeclarations to getGenerativeModel', async () => {
+    let capturedConfig: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel(config: any) {
+          capturedConfig = config;
+          return { generateContent: jest.fn().mockResolvedValue({
+            response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+          }) };
+        }
+      },
+    }), { virtual: true });
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(capturedConfig.tools[0]).toHaveProperty('functionDeclarations');
+    expect(capturedConfig.tools[0].functionDeclarations[0]).toMatchObject({
+      name: 'lisa_health',
+      description: 'Check server health',
+    });
+  });
+
+  it('parses functionCall parts from response', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: {
+        candidates: [{ content: { parts: [
+          { functionCall: { name: 'lisa_health', args: { verbose: true } } },
+        ] } }],
+      },
+    });
+    const provider = makeClient(mockGenerate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0].name).toBe('lisa_health');
+    expect(res.toolCalls![0].args).toEqual({ verbose: true });
+    expect(res.toolCalls![0].id).toMatch(/gemini-call-/);
+  });
+
+  it('formats second-turn tool result as functionResponse part', async () => {
+    let capturedContents: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return {
+            generateContent: jest.fn().mockImplementation(({ contents }: any) => {
+              capturedContents = contents;
+              return Promise.resolve({ response: { candidates: [{ content: { parts: [{ text: 'done' }] } }] } });
+            }),
+          };
+        }
+      },
+    }), { virtual: true });
+
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'gemini-call-0', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'gemini-call-0', content: 'ok' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const toolResultTurn = capturedContents.find((c: any) =>
+      c.parts?.some((p: any) => p.functionResponse),
+    );
+    expect(toolResultTurn).toBeDefined();
+    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({ response: { content: 'ok' } });
+  });
+
+  it('handles malformed args gracefully', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: {
+        candidates: [{ content: { parts: [
+          { functionCall: { name: 'lisa_health', args: 'bad' } },
+        ] } }],
+      },
+    });
+    const provider = makeClient(mockGenerate);
+    const res = await provider.chat({ messages: [USER_MSG], tools: [TOOL] });
+    expect(res.toolCalls![0].args).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider factory
+// ---------------------------------------------------------------------------
+
+describe('resolveToolCallingProvider()', () => {
+  const ORIG = process.env['LISA_LLM_PROVIDER'];
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env['LISA_LLM_PROVIDER'];
+    else process.env['LISA_LLM_PROVIDER'] = ORIG;
+  });
+
+  it('returns undefined when LISA_LLM_PROVIDER is unset', () => {
+    delete process.env['LISA_LLM_PROVIDER'];
+    expect(resolveToolCallingProvider()).toBeUndefined();
+  });
+
+  it('returns AnthropicToolCallingProvider for "anthropic"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'anthropic';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(AnthropicToolCallingProvider);
+  });
+
+  it('returns AnthropicToolCallingProvider for "claude"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'claude';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(AnthropicToolCallingProvider);
+  });
+
+  it('returns OpenAIToolCallingProvider for "openai"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'openai';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(OpenAIToolCallingProvider);
+  });
+
+  it('returns GeminiToolCallingProvider for "gemini"', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'gemini';
+    expect(resolveToolCallingProvider()).toBeInstanceOf(GeminiToolCallingProvider);
+  });
+
+  it('throws for unknown provider', () => {
+    process.env['LISA_LLM_PROVIDER'] = 'llama';
+    expect(() => resolveToolCallingProvider()).toThrow(/Unknown LISA_LLM_PROVIDER/);
+  });
+});

--- a/src/llm-providers/llm-providers.test.ts
+++ b/src/llm-providers/llm-providers.test.ts
@@ -279,7 +279,41 @@ describe('GeminiToolCallingProvider', () => {
       c.parts?.some((p: any) => p.functionResponse),
     );
     expect(toolResultTurn).toBeDefined();
-    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({ response: { content: 'ok' } });
+    expect(toolResultTurn.parts[0].functionResponse).toMatchObject({
+      name: 'lisa_health',      // must be tool name, NOT synthetic ID (gemini-call-0)
+      response: { content: 'ok' },
+    });
+  });
+
+  it('functionResponse.name resolves to tool name, not synthetic call id', async () => {
+    // Adapter-level round-trip: messages carry the same synthetic ID (gemini-call-0) that
+    // AgentLoopProvider produces. formatMessages() must resolve it back to the function name.
+    let capturedContents: any;
+    jest.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: class {
+        getGenerativeModel() {
+          return {
+            generateContent: jest.fn().mockImplementation(({ contents }: any) => {
+              capturedContents = contents;
+              return Promise.resolve({ response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] } });
+            }),
+          };
+        }
+      },
+    }), { virtual: true });
+
+    const provider = new GeminiToolCallingProvider({ apiKey: 'test-key' });
+    const messages: Message[] = [
+      USER_MSG,
+      { role: 'assistant', toolCalls: [{ id: 'gemini-call-0', name: 'lisa_health', args: {} }] },
+      { role: 'user', toolResults: [{ toolCallId: 'gemini-call-0', content: 'healthy' }] },
+    ];
+    await provider.chat({ messages, tools: [TOOL] });
+
+    const toolResultTurn = capturedContents.find((c: any) =>
+      c.parts?.some((p: any) => p.functionResponse),
+    );
+    expect(toolResultTurn.parts[0].functionResponse.name).toBe('lisa_health');
   });
 
   it('handles malformed args gracefully', async () => {

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -1,0 +1,85 @@
+import type { ToolCallingLlmProvider, ToolDefinition, Message, ChatResponse, ChatOptions } from './types';
+
+export class OpenAIToolCallingProvider implements ToolCallingLlmProvider {
+  readonly id: string;
+  private readonly model: string;
+  private readonly apiKey: string;
+
+  constructor({ model = 'gpt-4o', apiKey }: { model?: string; apiKey?: string } = {}) {
+    this.model = model;
+    this.id = `openai-tool:${model}`;
+    this.apiKey = apiKey ?? process.env['OPENAI_API_KEY'] ?? '';
+  }
+
+  async chat({ messages, tools, options = {} }: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await import('openai' as string).catch(() => {
+      throw new Error('OpenAIToolCallingProvider requires openai');
+    }) as { default: new (opts: { apiKey: string }) => any };
+
+    const client = new mod.default({ apiKey: this.apiKey });
+
+    const response = await client.chat.completions.create({
+      model: this.model,
+      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+      ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+      tools: tools.map(t => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        },
+      })),
+      messages: this.formatMessages(messages),
+    }) as { choices: Array<{ message?: { content?: string | null; tool_calls?: Array<{ id: string; function: { name: string; arguments: string } }> } }> };
+
+    const msg = response.choices[0]?.message;
+    if (!msg) return {};
+
+    const toolCalls = (msg.tool_calls ?? []).map(tc => ({
+      id: tc.id,
+      name: tc.function.name,
+      args: this.safeParseArgs(tc.function.arguments),
+    }));
+
+    return {
+      // content may be null on tool-only responses — treat as absent
+      ...(msg.content ? { content: msg.content } : {}),
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  private formatMessages(messages: Message[]): unknown[] {
+    const result: unknown[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'user' && msg.toolResults) {
+        // Each tool result is a separate tool message
+        for (const r of msg.toolResults) {
+          result.push({ role: 'tool', tool_call_id: r.toolCallId, content: r.content });
+        }
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'assistant',
+          content: msg.content ?? null,
+          tool_calls: msg.toolCalls.map(tc => ({
+            id: tc.id,
+            type: 'function',
+            function: { name: tc.name, arguments: JSON.stringify(tc.args) },
+          })),
+        });
+      } else {
+        result.push({ role: msg.role, content: msg.content ?? '' });
+      }
+    }
+    return result;
+  }
+
+  private safeParseArgs(args: string): Record<string, unknown> {
+    try { return JSON.parse(args); } catch { return {}; }
+  }
+}

--- a/src/llm-providers/types.ts
+++ b/src/llm-providers/types.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Tool-calling types — separate from the existing LlmProvider.complete() path
+// ---------------------------------------------------------------------------
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>; // JSON Schema object
+}
+
+export interface ToolCall {
+  id: string; // required — must be preserved into ToolResult for second-turn correlation
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolResult {
+  toolCallId: string;
+  content: string;
+}
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content?: string;
+  toolCalls?: ToolCall[];   // populated on assistant messages when model requests tools
+  toolResults?: ToolResult[]; // populated on user messages returning tool results
+}
+
+export interface ChatResponse {
+  content?: string;
+  toolCalls?: ToolCall[];
+}
+
+export interface ChatOptions {
+  temperature?: number;
+  maxTokens?: number;
+}
+
+/**
+ * Tool-calling LLM provider interface.
+ * Separate from LlmProvider.complete() — for models that support structured tool calls.
+ */
+export interface ToolCallingLlmProvider {
+  readonly id: string;
+  chat(params: {
+    messages: Message[];
+    tools: ToolDefinition[];
+    options?: ChatOptions;
+  }): Promise<ChatResponse>;
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -259,7 +259,7 @@ export class FabricOrchestrator {
         this.log('[orchestrate] GENERATE_FLOWS: no candidate_flows.yaml — nothing to generate');
         return;
       }
-      const provider = resolveProvider(flowModel, llmProvider);
+      const provider = resolveProvider(flowModel, llmProvider, { iterRoot: iterPaths.iterRoot });
       if (!provider) {
         this.log(
           '[orchestrate] GENERATE_FLOWS: no LLM provider configured — skipping. ' +


### PR DESCRIPTION
Brings the STF #5 and #6 work (merged to main via PRs #8 and #9) into the develop branch.

## Included
- **#8** `feat(llm-providers)`: ToolCallingLlmProvider — Anthropic, OpenAI, Gemini adapters (22 tests)
- **fix(gemini)**: functionResponse.name must be tool name, not synthetic call id
- **#9** `feat(agent-loop)`: AgentLoopProvider + LISA_LLM_PROVIDER wiring — factory per complete() call, spawn inside try, options pass-through (21 tests)

245/245 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)