### PR TITLE
docs: update for v0.3.0 LLM-agnostic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,20 +160,33 @@ The score drives the next iteration — low `novelty` steers the planner toward 
 | **HTML trend report** | `HtmlReporter` generates a self-contained report with Chart.js trend across the last 30 iterations |
 | **Headless HTTP** | `ApiExecutor` records behavior events without a browser — 80× faster than Playwright for simulation |
 | **LLM element inference** | `@kaneshir/lisa-mcp` peer gives BrowserAdapter AI-driven key discovery via the Lisa MCP server |
+| **LLM-agnostic flow generation** | `LISA_LLM_PROVIDER=anthropic\|openai\|gemini` swaps the GENERATE_FLOWS LLM without code changes |
 
 ---
 
 ## How it relates to `@kaneshir/lisa-mcp`
 
-`@kaneshir/lisa-mcp` is an optional peer package that ships a precompiled Lisa MCP server binary. It enables the LLM-driven element inference path in the GENERATE_FLOWS step — the Lisa MCP server navigates your live app, discovers interactive elements by their stable identifiers, and produces Playwright locators without hand-labeling selectors. It works with any web app; see [docs/lisa-mcp.md](docs/lisa-mcp.md) for the full integration guide.
+`@kaneshir/lisa-mcp` is an optional peer package that ships a precompiled Lisa MCP server binary. It has two integration paths:
 
-Without it: your `BrowserAdapter` supplies its own selectors (data-testid, hard-coded, etc.) — fully supported.
+**Path 1 — BrowserAdapter element inference (original)**
+Your `BrowserAdapter.runSpecs()` calls `buildLisaMcpCommand()`, spawns the MCP server, and lets an LLM use `lisa_explore_screen` / `lisa_tap_key` tools to discover interactive elements and generate Playwright spec steps from actual observations.
 
-With it: your `BrowserAdapter.runSpecs()` implementation can call `buildLisaMcpCommand()` to get the binary path, spawn the MCP server, and let an LLM use `lisa_explore_screen` / `lisa_tap_key` tools to navigate the live app and generate spec steps from actual observations before executing them.
+**Path 2 — Agentic loop via `LISA_LLM_PROVIDER` (v0.3.0+)**
+Set `LISA_LLM_PROVIDER=anthropic|openai|gemini` and the framework automatically spawns the binary as an `AgentLoopProvider`. The LLM drives a full multi-turn tool-call loop — no custom `BrowserAdapter` wiring needed. The binary's tool list is fetched at runtime; tool calls are dispatched back via MCP `tools/call`.
 
 ```bash
-npm install @kaneshir/lisa-mcp
+# Zero-config agentic loop with OpenAI
+npm install @kaneshir/lisa-mcp openai
+LISA_LLM_PROVIDER=openai OPENAI_API_KEY=sk-... npx fab orchestrate
+
+# Or Anthropic
+npm install @kaneshir/lisa-mcp @anthropic-ai/sdk
+LISA_LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-... npx fab orchestrate
 ```
+
+Without `@kaneshir/lisa-mcp`: your `BrowserAdapter` supplies its own selectors — fully supported. `LISA_LLM_PROVIDER` requires it.
+
+See [docs/lisa-mcp.md](docs/lisa-mcp.md) and [docs/env-vars.md](docs/env-vars.md) for full integration details.
 
 ---
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -12,6 +12,7 @@ set them before calling `orchestrator.run()` — they are optional unless noted.
 
 | Variable | Required | Read by | Effect if missing |
 |----------|----------|---------|-------------------|
+| `LISA_LLM_PROVIDER` | No | `resolveProvider()` (GENERATE_FLOWS) | Falls through to Claude CLI / API-key auto-detection |
 | `ANTHROPIC_API_KEY` | No | `resolveProvider()` (GENERATE_FLOWS) | Falls through to next provider in auto-detection order |
 | `OPENAI_API_KEY` | No | `resolveProvider()` (GENERATE_FLOWS) | Falls through to next provider in auto-detection order |
 | `GEMINI_API_KEY` | No | `resolveProvider()` (GENERATE_FLOWS) | Falls through to next provider in auto-detection order |
@@ -21,20 +22,64 @@ set them before calling `orchestrator.run()` — they are optional unless noted.
 
 ### GENERATE_FLOWS provider auto-detection
 
-When no `llmProvider` or `flowModel` is set in `OrchestratorOptions`, the
-framework probes for a provider in this order:
+When no `llmProvider` is set in `OrchestratorOptions`, the framework probes
+for a provider in this order:
 
-1. `claude` CLI in PATH **and** `STF_DISABLE_CLAUDE_CLI` unset → `ClaudeCliProvider`
+1. **`LISA_LLM_PROVIDER` set** → `AgentLoopProvider` wrapping the matching
+   `ToolCallingLlmProvider` adapter (Anthropic, OpenAI, or Gemini). The loop
+   spawns the `@kaneshir/lisa-mcp` binary and drives it via real tool calls.
+   See [`LISA_LLM_PROVIDER`](#lisa_llm_provider) below.
+2. `flowModel` starts with `'ollama:'` → `OllamaProvider`
+3. `flowModel` set to any other string → `GeminiProvider` (legacy)
+4. `claude` CLI in PATH **and** `STF_DISABLE_CLAUDE_CLI` unset → `ClaudeCliProvider`
    (uses your Claude.ai subscription — no API key needed)
-2. `ANTHROPIC_API_KEY` set → `ClaudeSdkProvider`
-3. `OPENAI_API_KEY` set → `OpenAIProvider`
-4. `GEMINI_API_KEY` set → `GeminiProvider`
-5. None → GENERATE_FLOWS skipped (non-fatal; TEST phase runs normally)
+5. `ANTHROPIC_API_KEY` set → `ClaudeSdkProvider`
+6. `OPENAI_API_KEY` set → `OpenAIProvider`
+7. `GEMINI_API_KEY` set → `GeminiProvider`
+8. None → GENERATE_FLOWS skipped (non-fatal; TEST phase runs normally)
+
+### `LISA_LLM_PROVIDER`
+
+Activates the **agentic tool-call loop** for GENERATE_FLOWS. When set, the
+framework instantiates an `AgentLoopProvider` that spawns the
+`@kaneshir/lisa-mcp` binary, fetches its tool list, and drives a multi-turn
+conversation with the selected LLM — routing tool calls back to the binary
+rather than using a simple `complete()` prompt.
+
+**Valid values:**
+
+| Value | SDK used | Peer dep required |
+|-------|----------|-------------------|
+| `anthropic` or `claude` | `@anthropic-ai/sdk` | `npm install @anthropic-ai/sdk` |
+| `openai` | `openai` | `npm install openai` |
+| `gemini` | `@google/generative-ai` | `npm install @google/generative-ai` |
+
+The corresponding API key env var must also be set (`ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, or `GEMINI_API_KEY`).
+
+**`@kaneshir/lisa-mcp` is required** when `LISA_LLM_PROVIDER` is set — the
+agentic loop spawns the binary on every `complete()` call:
+
+```bash
+npm install @kaneshir/lisa-mcp
+```
+
+**Quick start:**
+
+```bash
+LISA_LLM_PROVIDER=openai OPENAI_API_KEY=sk-... npx fab orchestrate
+LISA_LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-... npx fab orchestrate
+LISA_LLM_PROVIDER=gemini GEMINI_API_KEY=... npx fab orchestrate
+```
+
+When unset, the framework falls through to Claude CLI / API-key auto-detection
+(steps 4–8 above). The Claude CLI path is the zero-config default for most
+users.
 
 ### `ANTHROPIC_API_KEY`
 
-Enables `ClaudeSdkProvider` — used when no `llmProvider` is set, the `claude`
-CLI is absent or disabled, and this key is present. Get a key from
+Enables `ClaudeSdkProvider` (step 5 fallback) or `AnthropicToolCallingProvider`
+(when `LISA_LLM_PROVIDER=anthropic`). Get a key from
 [console.anthropic.com](https://console.anthropic.com).
 
 ### `OPENAI_API_KEY`

--- a/docs/lisa-mcp.md
+++ b/docs/lisa-mcp.md
@@ -257,6 +257,53 @@ The TEST phase does not change. lisa-mcp only touches GENERATE_FLOWS.
 
 ---
 
+## LLM-agnostic agentic loop (v0.3.0+)
+
+Setting `LISA_LLM_PROVIDER` activates a second integration mode that requires
+no custom `BrowserAdapter` wiring. The framework spawns the binary itself and
+drives it via a multi-turn tool-call loop:
+
+```
+GENERATE_FLOWS with LISA_LLM_PROVIDER=openai:
+  1. resolveProvider() creates AgentLoopProvider(OpenAIToolCallingProvider, mcpClientFactory)
+  2. For each prompt in candidate_flows.yaml:
+     a. mcpClientFactory() spawns the lisa-mcp binary fresh
+     b. tools/list → tool definitions sent to OpenAI with the prompt
+     c. LLM returns tool_calls → dispatched via tools/call to the binary
+     d. Tool results injected back → loop continues until text response
+     e. Binary process closed
+  3. Text response written as the generated spec
+```
+
+**When to use which mode:**
+
+| Mode | How | Best for |
+|------|-----|----------|
+| BrowserAdapter wiring | Call `buildLisaMcpCommand()` in your adapter | Full control over prompt construction and spec format |
+| `LISA_LLM_PROVIDER` | Set env var, install SDK peer | Zero-config; any LLM; no adapter code required |
+
+The two modes are independent. You can use both simultaneously — `LISA_LLM_PROVIDER` controls the LLM for the top-level agentic loop; your adapter's internal MCP calls are unaffected.
+
+**Required packages for `LISA_LLM_PROVIDER`:**
+
+```bash
+# Anthropic
+npm install @kaneshir/lisa-mcp @anthropic-ai/sdk
+LISA_LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI
+npm install @kaneshir/lisa-mcp openai
+LISA_LLM_PROVIDER=openai OPENAI_API_KEY=sk-...
+
+# Gemini
+npm install @kaneshir/lisa-mcp @google/generative-ai
+LISA_LLM_PROVIDER=gemini GEMINI_API_KEY=...
+```
+
+See [docs/env-vars.md](env-vars.md) for the full resolution order.
+
+---
+
 ## Troubleshooting
 
 **`Error: unsupported platform: win32`**

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -21,20 +21,49 @@ Everything exported from `synthetic-test-fabric`. Grouped by category.
 
 ## LLM providers
 
-Used by the GENERATE_FLOWS phase. See `docs/orchestrator-reference.md` for the full resolution order.
+Used by the GENERATE_FLOWS phase. See `docs/env-vars.md` for the full resolution order and `LISA_LLM_PROVIDER` usage.
+
+### Simple providers — `complete(prompt): Promise<string>`
 
 | Export | Kind | Description |
 |--------|------|-------------|
-| `LlmProvider` | type | Interface all providers implement: `id: string` + `complete(prompt, opts?): Promise<string>`. |
+| `LlmProvider` | type | Interface: `id: string` + `complete(prompt, opts?): Promise<string>`. |
 | `ClaudeCliProvider` | class | Spawns `claude -p` subprocess. Uses Claude.ai subscription — no API key needed. Zero-config default when `claude` is in PATH. |
 | `ClaudeSdkProvider` | class | Calls Anthropic API via `@anthropic-ai/sdk`. Requires `ANTHROPIC_API_KEY` or explicit `apiKey`. Peer dep: `npm install @anthropic-ai/sdk`. |
 | `GeminiProvider` | class | Calls Google Generative AI via `@google/generative-ai`. Requires `GEMINI_API_KEY`. Peer dep: `npm install @google/generative-ai`. |
 | `OllamaProvider` | class | Calls local Ollama HTTP API. No API key. Reads `OLLAMA_HOST` (default: `http://localhost:11434`). |
 | `OpenAIProvider` | class | Calls OpenAI API via `openai` package. Covers GPT-4o, o3, Codex. Requires `OPENAI_API_KEY`. Peer dep: `npm install openai`. |
-| `resolveProvider` | function | `(flowModel, llmProvider) => LlmProvider \| undefined`. Runs the 8-step resolution order. Useful for testing or custom orchestration. |
 | `claudeCliAvailable` | function | `() => boolean`. Returns true if `claude` is in PATH. |
-| `DEFAULT_CLAUDE_SDK_MODEL` | const | Default model string for `ClaudeSdkProvider`. Verify against Anthropic models page before major releases. |
+| `DEFAULT_CLAUDE_SDK_MODEL` | const | Default model string for `ClaudeSdkProvider`. |
 | `DEFAULT_GEMINI_MODEL` | const | Default model string for `GeminiProvider` (`'gemini-1.5-pro'`). |
+
+### Agentic tool-call loop (v0.3.0+)
+
+Activated by `LISA_LLM_PROVIDER`. Requires `@kaneshir/lisa-mcp`.
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `AgentLoopProvider` | class | Implements `LlmProvider` via multi-turn tool-call loop. Constructor: `(toolProvider: ToolCallingLlmProvider, mcpClientFactory: () => McpClient, opts?)`. Each `complete()` call creates a fresh `McpClient`, fetches tools, drives the LLM ↔ MCP loop until a text response or `maxIterations` (default 10), then closes the client. |
+| `ToolCallingLlmProvider` | type | Interface for SDK-level tool calling: `{ id: string; chat({ messages, tools, options? }): Promise<ChatResponse> }`. |
+| `AnthropicToolCallingProvider` | class | Wraps `@anthropic-ai/sdk`. Formats tools as `input_schema`, parses `tool_use` blocks, serializes second-turn results as `tool_result` content blocks. |
+| `OpenAIToolCallingProvider` | class | Wraps `openai`. Formats tools as `type:function`, parses `tool_calls`, serializes second-turn results as `role:tool` messages. |
+| `GeminiToolCallingProvider` | class | Wraps `@google/generative-ai`. Uses camelCase `functionDeclarations`, parses `functionCall` parts (positional IDs `gemini-call-N`), serializes results as `functionResponse` parts with the original function name resolved from the preceding assistant turn. |
+
+### Supporting types (tool-call loop)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `ToolDefinition` | type | `{ name, description, parameters }` — neutral tool schema passed to `chat()`. |
+| `ToolCall` | type | `{ id, name, args }` — a tool call returned by the LLM. |
+| `ToolResult` | type | `{ toolCallId, content }` — result injected back into the conversation. |
+| `Message` | type | Union of user, assistant (with optional `toolCalls`), and tool-result turns. |
+| `ChatResponse` | type | `{ content?, toolCalls? }` — response from `chat()`. |
+
+### Provider resolution
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `resolveProvider` | function | `(flowModel?, llmProvider?, { iterRoot? }?) => LlmProvider \| undefined`. Runs the 9-step resolution order including `LISA_LLM_PROVIDER`. |
 
 ---
 


### PR DESCRIPTION
Updates four files that were missing coverage of the v0.3.0 features.

## What changed
- **env-vars.md** — `LISA_LLM_PROVIDER` section (valid values, peer deps, quick-start, updated 9-step resolution order)
- **package-exports.md** — `AgentLoopProvider`, `ToolCallingLlmProvider`, three adapters, supporting types, updated `resolveProvider()` signature
- **README.md** — `LISA_LLM_PROVIDER` in advanced features table; lisa-mcp section now covers both integration modes
- **lisa-mcp.md** — new "LLM-agnostic agentic loop" section with flow diagram, mode comparison table, and per-provider setup snippets

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)