### PR TITLE
chore(deps): update @kaneshir/lisa-mcp to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@google/generative-ai": "^0.24.1",
-        "@kaneshir/lisa-mcp": "^1.0.1",
+        "@kaneshir/lisa-mcp": "^1.0.2",
         "@playwright/test": "^1.44.0",
         "@types/better-sqlite3": "^7.6.8",
         "@types/jest": "^29.5.12",
@@ -43,7 +43,7 @@
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.20.0",
         "@google/generative-ai": ">=0.1.0",
-        "@kaneshir/lisa-mcp": "^1.0.1",
+        "@kaneshir/lisa-mcp": "^1.0.2",
         "@playwright/test": "^1.44.0",
         "openai": ">=4.0.0"
       },
@@ -1534,10 +1534,11 @@
       }
     },
     "node_modules/@kaneshir/lisa-mcp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@kaneshir/lisa-mcp/-/lisa-mcp-1.0.1.tgz",
-      "integrity": "sha512-uKFCO6r3ctL5xl3GvrzEUSlOtgSRMum+kSghcZpe2OVbov4NNP8eySEv1eXn44L2VbsvgDODv85WEnzQbaQfgA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@kaneshir/lisa-mcp/-/lisa-mcp-1.0.2.tgz",
+      "integrity": "sha512-tSyx/92xWoHYaZ57XtD7FU4g4EasQ8pHE24SPfKKXYzN8toeeYme9Gf2cuj9nSbQEEGVdsA6ny6JAeNvrZ7Alw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "lisa-mcp": "cli.js"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@google/generative-ai": "^0.24.1",
-    "@kaneshir/lisa-mcp": "^1.0.1",
+    "@kaneshir/lisa-mcp": "^1.0.2",
     "@playwright/test": "^1.44.0",
     "@types/better-sqlite3": "^7.6.8",
     "@types/jest": "^29.5.12",
@@ -110,7 +110,7 @@
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
     "@google/generative-ai": ">=0.1.0",
-    "@kaneshir/lisa-mcp": "^1.0.1",
+    "@kaneshir/lisa-mcp": "^1.0.2",
     "@playwright/test": "^1.44.0",
     "openai": ">=4.0.0"
   },


### PR DESCRIPTION
## Summary

- Bumps `@kaneshir/lisa-mcp` from `^1.0.1` to `^1.0.2` in devDependencies and peerDependencies
- Picks up the Lisa epic #465 changes compiled into the binary (Dart-side LLM agent loop, tool-calling support across all providers, replay fixture persistence for tool calls)

## What's in the binary

The MCP wire interface is unchanged — the binary still exposes the same 25 tools over stdio. The new code compiled in:
- `LlmAgent` multi-turn tool-call loop with full `transcript: List<ChatMessage>`
- Tool-calling params on all Dart LLM providers (OpenAI, Anthropic, Gemini, Ollama)
- `LisaMcpServer.buildLisaAgent()` + `E2EHarness.runLlmSession()` for Dart-side orchestration
- Replay fixtures now persist and restore `toolCalls` correctly (`ToolCall.toJson/fromJson`)

No STF TypeScript code changes required — `AgentLoopProvider`, `McpClient`, and `resolveProvider()` continue to work against the same MCP tool contract.

## Test plan

- [x] `npx jest` — 245/245 tests passing across 12 suites
- [x] `agent-loop.test.ts` real-binary integration tests pass (spawns 1.0.2 binary, runs `lisa_health` tool, verifies full loop)
- [x] `npx tsc --noEmit` — zero type errors
- [x] `verifyBinary()` via installed 1.0.2 package — MCP handshake ✓, version 1.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)