### PR TITLE
docs: lisa-mcp quickstart, resolveProvider 9-step order, McpClient exports

### DIFF
--- a/docs/orchestrator-reference.md
+++ b/docs/orchestrator-reference.md
@@ -190,9 +190,8 @@ regression suite. See `docs/env-vars.md` for how to configure each provider.
 
 **`LISA_LLM_PROVIDER` and `resolveProvider()`**
 
-`resolveProvider()` is the internal function that implements the full 9-step
-resolution order. It runs _before_ the priority table above, so `LISA_LLM_PROVIDER`
-takes precedence over all other detection:
+`resolveProvider()` is the internal function that runs the full resolution order.
+`LISA_LLM_PROVIDER` takes precedence over all env-var auto-detection:
 
 | Step | Condition | Result |
 |------|-----------|--------|
@@ -203,12 +202,15 @@ takes precedence over all other detection:
 | 5 | `flowModel` matches `'ollama:<model>'` | `OllamaProvider` |
 | 6 | `flowModel` is any other string | `GeminiProvider({ model: flowModel })` |
 | 7 | `claude` CLI in PATH and `STF_DISABLE_CLAUDE_CLI` unset | `ClaudeCliProvider` |
-| 8 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` set | matching SDK provider |
-| 9 | nothing | `undefined` — GENERATE_FLOWS skipped |
+| 8 | `ANTHROPIC_API_KEY` set | `ClaudeSdkProvider` |
+| 9 | `OPENAI_API_KEY` set | `OpenAIProvider` |
+| 10 | `GEMINI_API_KEY` set | `GeminiProvider` |
+| — | nothing | `undefined` — GENERATE_FLOWS skipped |
 
-`AgentLoopProvider` requires `@kaneshir/lisa-mcp` to be installed. It spawns a
-fresh MCP binary per `complete()` call and runs a multi-turn tool-call loop
-(`tools/list` → dispatch → `tools/call`) until the LLM returns a text response.
+Steps 8–10 are checked in order — if multiple keys are set, Anthropic wins.
+`AgentLoopProvider` requires `@kaneshir/lisa-mcp`. It spawns a fresh MCP binary
+per `complete()` call and runs a multi-turn tool-call loop (`tools/list` →
+dispatch → `tools/call`) until the LLM returns a text response.
 
 ---
 

--- a/docs/orchestrator-reference.md
+++ b/docs/orchestrator-reference.md
@@ -188,6 +188,28 @@ When `flowModel` is omitted, the framework auto-detects a provider in this order
 If GENERATE_FLOWS is skipped, the TEST phase will still run the existing
 regression suite. See `docs/env-vars.md` for how to configure each provider.
 
+**`LISA_LLM_PROVIDER` and `resolveProvider()`**
+
+`resolveProvider()` is the internal function that implements the full 9-step
+resolution order. It runs _before_ the priority table above, so `LISA_LLM_PROVIDER`
+takes precedence over all other detection:
+
+| Step | Condition | Result |
+|------|-----------|--------|
+| 1 | `llmProvider` option is set | use it directly |
+| 2 | `LISA_LLM_PROVIDER=anthropic` + `@kaneshir/lisa-mcp` installed | `AgentLoopProvider(AnthropicToolCallingProvider, mcpClientFactory)` |
+| 3 | `LISA_LLM_PROVIDER=openai` + `@kaneshir/lisa-mcp` installed | `AgentLoopProvider(OpenAIToolCallingProvider, mcpClientFactory)` |
+| 4 | `LISA_LLM_PROVIDER=gemini` + `@kaneshir/lisa-mcp` installed | `AgentLoopProvider(GeminiToolCallingProvider, mcpClientFactory)` |
+| 5 | `flowModel` matches `'ollama:<model>'` | `OllamaProvider` |
+| 6 | `flowModel` is any other string | `GeminiProvider({ model: flowModel })` |
+| 7 | `claude` CLI in PATH and `STF_DISABLE_CLAUDE_CLI` unset | `ClaudeCliProvider` |
+| 8 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` set | matching SDK provider |
+| 9 | nothing | `undefined` — GENERATE_FLOWS skipped |
+
+`AgentLoopProvider` requires `@kaneshir/lisa-mcp` to be installed. It spawns a
+fresh MCP binary per `complete()` call and runs a multi-turn tool-call loop
+(`tools/list` → dispatch → `tools/call`) until the LLM returns a text response.
+
 ---
 
 ### `dbUrl` — `string` (optional)

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -67,6 +67,38 @@ Activated by `LISA_LLM_PROVIDER`. Requires `@kaneshir/lisa-mcp`.
 
 ---
 
+## MCP client
+
+Used internally by `AgentLoopProvider`. Exported for consumers who need to
+spawn and communicate with an MCP server directly (e.g. from a custom
+`BrowserAdapter`).
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `McpClient` | class | Spawns an MCP server binary over stdio and communicates via JSON-RPC. `getTools()` calls `tools/list`; `callTool(name, args)` calls `tools/call`. Call `close()` when done to kill the child process. |
+| `createMcpClient` | function | `(options: McpClientOptions) => McpClient`. Factory that sets up the stdio transport and attaches the MCP handshake. |
+| `McpClientOptions` | type | `{ cmd: string; args?: string[]; env?: Record<string, string> }` — passed to `createMcpClient`. |
+| `McpTool` | type | `{ name: string; description: string; inputSchema: object }` — one entry in the `tools/list` response. |
+| `McpCallResult` | type | `{ content: Array<{ type: 'text'; text: string }> }` — response from `tools/call`. |
+
+**Example — call lisa-mcp directly from a BrowserAdapter:**
+
+```typescript
+import { createMcpClient } from 'synthetic-test-fabric';
+import { buildLisaMcpCommand } from '@kaneshir/lisa-mcp';
+
+const { cmd, args } = buildLisaMcpCommand();
+const client = createMcpClient({ cmd, args, env: { LISA_APP_URL: 'http://localhost:5002' } });
+
+const tools = await client.getTools();
+const result = await client.callTool('lisa_health', {});
+console.log(result.content[0].text); // '{"status":"ok"}'
+
+await client.close();
+```
+
+---
+
 ## Adapter interfaces
 
 | Export | Kind | Description |

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -75,11 +75,11 @@ spawn and communicate with an MCP server directly (e.g. from a custom
 
 | Export | Kind | Description |
 |--------|------|-------------|
-| `McpClient` | class | Spawns an MCP server binary over stdio and communicates via JSON-RPC. `getTools()` calls `tools/list`; `callTool(name, args)` calls `tools/call`. Call `close()` when done to kill the child process. |
-| `createMcpClient` | function | `(options: McpClientOptions) => McpClient`. Factory that sets up the stdio transport and attaches the MCP handshake. |
-| `McpClientOptions` | type | `{ cmd: string; args?: string[]; env?: Record<string, string> }` — passed to `createMcpClient`. |
-| `McpTool` | type | `{ name: string; description: string; inputSchema: object }` — one entry in the `tools/list` response. |
-| `McpCallResult` | type | `{ content: Array<{ type: 'text'; text: string }> }` — response from `tools/call`. |
+| `McpClient` | class | Spawns an MCP server binary over stdio and communicates via JSON-RPC. Call `await spawn()` before using `getTools()` or `callTool(name, args)`. Call `close()` when done to kill the child process. |
+| `createMcpClient` | function | `(iterRoot: string, opts?: Omit<McpClientOptions, 'memoryDir'>) => McpClient`. Convenience factory — derives `memoryDir` as `<iterRoot>/.lisa_memory`. |
+| `McpClientOptions` | type | `{ memoryDir: string; appUrl?: string; command?: { cmd: string; args: string[] }; timeoutMs?: number }`. `command` overrides the default binary; omit to use `@kaneshir/lisa-mcp` auto-detection. |
+| `McpTool` | type | `{ name: string; description: string; inputSchema: Record<string, unknown> }` — one entry from `tools/list`. |
+| `McpCallResult` | type | `{ content: Array<{ type: string; text?: string }>; isError?: boolean }` — response from `tools/call`. |
 
 **Example — call lisa-mcp directly from a BrowserAdapter:**
 
@@ -88,13 +88,20 @@ import { createMcpClient } from 'synthetic-test-fabric';
 import { buildLisaMcpCommand } from '@kaneshir/lisa-mcp';
 
 const { cmd, args } = buildLisaMcpCommand();
-const client = createMcpClient({ cmd, args, env: { LISA_APP_URL: 'http://localhost:5002' } });
+// createMcpClient derives memoryDir from iterRoot + '/.lisa_memory'
+const client = createMcpClient(iterRoot, {
+  appUrl: 'http://localhost:5002',
+  command: { cmd, args },
+});
 
-const tools = await client.getTools();
-const result = await client.callTool('lisa_health', {});
-console.log(result.content[0].text); // '{"status":"ok"}'
-
-await client.close();
+await client.spawn(); // must call before getTools() / callTool()
+try {
+  const tools = await client.getTools();
+  const result = await client.callTool('lisa_health', {});
+  console.log(result.content[0]?.text); // '{"status":"ok"}'
+} finally {
+  client.close();
+}
 ```
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,34 @@ npm install synthetic-test-fabric
 
 Peer requirements: Node.js 20+, TypeScript 5+.
 
+**Optional — LLM-driven flow generation:**
+
+```bash
+npm install @kaneshir/lisa-mcp
+```
+
+With `@kaneshir/lisa-mcp` installed, set `LISA_LLM_PROVIDER` to activate the
+agentic GENERATE_FLOWS loop. The framework spawns the MCP binary automatically
+and drives a multi-turn tool-call session against your app:
+
+```bash
+# Anthropic (requires @anthropic-ai/sdk peer)
+npm install @kaneshir/lisa-mcp @anthropic-ai/sdk
+LISA_LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-... npx fab orchestrate
+
+# OpenAI (requires openai peer)
+npm install @kaneshir/lisa-mcp openai
+LISA_LLM_PROVIDER=openai OPENAI_API_KEY=sk-... npx fab orchestrate
+
+# Gemini (requires @google/generative-ai peer)
+npm install @kaneshir/lisa-mcp @google/generative-ai
+LISA_LLM_PROVIDER=gemini GEMINI_API_KEY=... npx fab orchestrate
+```
+
+Without `@kaneshir/lisa-mcp`, your `BrowserAdapter` supplies its own selectors
+and flow generation is fully manual — this is supported and is the default.
+See [docs/lisa-mcp.md](./lisa-mcp.md) for the full integration guide.
+
 ---
 
 ## 2. Implement the adapters


### PR DESCRIPTION
## Summary

- **`docs/quickstart.md`**: add optional `@kaneshir/lisa-mcp` install block with `LISA_LLM_PROVIDER` examples for all three supported providers (Anthropic, OpenAI, Gemini)
- **`docs/orchestrator-reference.md`**: expand `flowModel` section with a complete `resolveProvider()` 9-step resolution table; documents where `LISA_LLM_PROVIDER` slots in and what `AgentLoopProvider` does at runtime
- **`docs/package-exports.md`**: add MCP client section documenting `McpClient`, `createMcpClient`, `McpClientOptions`, `McpTool`, `McpCallResult` — all exported since v0.3.0 but previously undocumented

## Test plan

- [ ] `docs/quickstart.md` renders install block correctly in GitHub markdown
- [ ] `resolveProvider()` table in orchestrator-reference.md aligns with actual 9-step logic in `src/llm-provider.ts`
- [ ] `McpClient` example in package-exports.md matches actual interface in `src/mcp-client.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)