### PR TITLE
fix(contributing): correct test command, remove stale PR reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,6 @@ framework runtime, a cloud provider client), it belongs in the consumer repo.
 ## Running tests
 
 ```bash
-cd packages/test-fabric-core
 npm test
 ```
 
@@ -44,8 +43,6 @@ npm run check:boundary
 ```
 
 Run this before submitting a PR. The CI gate also runs it automatically.
-(The `check:boundary` script is wired in by the `feat/ci-gates-1559` PR.
-Until that lands, run `npx tsx scripts/check-boundary.ts` directly.)
 
 ## Adapter interface stability
 


### PR DESCRIPTION
## Summary

- `cd packages/test-fabric-core` doesn't exist — repo is a flat package. Corrected to `npm test` from root.
- Removed the parenthetical about `feat/ci-gates-1559` being pending; that gate has been wired since v0.2 and the branch is long gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)