### PR TITLE
feat: fab JSON output envelope on all commands (#18)

### DIFF
--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -1,0 +1,171 @@
+# `fab` JSON output contract
+
+Every `fab` command accepts `--json`. When set, stdout contains exactly one JSON
+object per invocation — the **envelope**. Default text mode is unchanged.
+
+This contract is the foundation for `fab status` (#19), `fab inspect` (#20),
+`fab adapter validate` (#23), `fab doctor` (#24), and the `fab-mcp` server (#27).
+Future commands MUST follow it.
+
+---
+
+## Envelope schema
+
+```ts
+type FabResult =
+  | { command: string; status: "ok";    data: unknown; runRoot?: string; next?: string }
+  | { command: string; status: "error"; error: { message: string; code?: string; stack?: string }; runRoot?: string };
+```
+
+| Field | When present | Notes |
+|-------|--------------|-------|
+| `command` | Always | The `fab` subcommand that ran (e.g. `"smoke"`, `"check"`). |
+| `status` | Always | `"ok"` or `"error"`. **Describes infrastructure outcome**, not domain outcome. |
+| `data` | When `status: "ok"` | Command-specific shape. May include `data.ok: boolean` for domain-check commands. |
+| `error` | When `status: "error"` | `{message, code?, stack?}`. `stack` only when `--debug` or `FAB_DEBUG=1`. |
+| `runRoot` | Optional | Loop root the command operated on, if applicable. |
+| `next` | Optional | Suggested follow-up command string. |
+
+---
+
+## CLI outcome taxonomy
+
+Three uniform categories. Every command's outcome maps to one of them:
+
+| Outcome | Envelope shape | Exit code |
+|---------|---------------|-----------|
+| **Success** | `{status: "ok", data: <command-shape> \| {ok: true, ...}}` | `0` |
+| **Domain check failed** (tool ran, found problems) | `{status: "ok", data: {ok: false, ...details}}` | `1` |
+| **Infrastructure / runtime error** (tool couldn't run) | `{status: "error", error: {message, code?}}` (no `data`) | `1` |
+
+The distinction matters because agents need to know whether to retry the call
+vs. consume structured findings.
+
+- **`status: "error"`** means the tool itself broke (file not found, parse error,
+  unexpected exception). Retry-able or report-able.
+- **`status: "ok"` + `data.ok: false`** means the tool worked, but the input
+  failed a check. Read `data` and act.
+
+### Examples
+
+**Success** — `fab check --root ./loop --threshold 0.5 --json` (score 0.85):
+```json
+{"command":"check","status":"ok","data":{"ok":true,"score":0.85,"threshold":0.5},"runRoot":"./loop"}
+```
+Exit code: `0`.
+
+**Domain check failed** — `fab check --root ./loop --threshold 0.5 --json` (score 0.30):
+```json
+{"command":"check","status":"ok","data":{"ok":false,"score":0.30,"threshold":0.5,"message":"Score 0.3 below threshold 0.5"},"runRoot":"./loop"}
+```
+Exit code: `1`.
+
+**Infrastructure error** — `fab check --root ./missing --threshold 0.5 --json`:
+```json
+{"command":"check","status":"error","error":{"message":"fabric-score.json not found at ./missing/iter-001/fabric-score.json","code":"SCORE_FILE_MISSING"},"runRoot":"./missing"}
+```
+Exit code: `1`.
+
+---
+
+## Caller contract — read both
+
+> **Automation MUST key off both the process exit code AND the envelope fields.**
+
+- **`status`** — describes infrastructure outcome ("did the tool itself succeed?")
+- **`data.ok`** — describes domain outcome where applicable ("did the input pass the check?")
+- **Exit code** — must be checked even on `status: "ok"`, because `status: "ok"` + `data.ok: false` is a normal domain failure with exit 1.
+
+Reference caller logic:
+
+```bash
+output=$(fab check --root ./loop --threshold 0.5 --json)
+exit_code=$?
+status=$(echo "$output" | jq -r '.status')
+ok=$(echo "$output" | jq -r '.data.ok // empty')
+
+if [ "$exit_code" -ne 0 ] && [ "$status" = "error" ]; then
+  echo "Tool broke — investigate"
+elif [ "$exit_code" -ne 0 ] && [ "$ok" = "false" ]; then
+  echo "Domain check failed — fix input and retry"
+else
+  echo "Success"
+fi
+```
+
+This convention prevents future commands from overloading `status: "error"` for
+expected validation failures.
+
+---
+
+## Stdout purity guarantee
+
+When `--json` is set:
+
+- Stdout contains **exactly one** JSON envelope per invocation
+- All progress, framing, adapter, and reporter logs route to **stderr**
+- `JSON.parse(stdout)` succeeds with no extra bytes
+- Adapter `console.log()` and `process.stdout.write()` calls do **not** corrupt
+  the envelope — the CLI installs a global stdout guard that redirects them
+
+Default (text) mode is unchanged: `[fab smoke] 3/5 passed` still appears on stdout.
+
+### `--json` detection
+
+Detected from raw `process.argv` BEFORE commander parses, so even
+unknown-command and missing-required-option errors emit a JSON envelope when
+`--json` is in argv:
+
+```bash
+$ fab nonexistent --json
+{"command":"nonexistent","status":"error","error":{"message":"unknown command 'nonexistent'"}}
+$ echo $?
+1
+
+$ fab seed --json
+{"command":"seed","status":"error","error":{"message":"required option '--root <dir>' not specified"}}
+$ echo $?
+1
+```
+
+---
+
+## Debug mode
+
+`--debug` (or `FAB_DEBUG=1`) includes stack traces in error envelopes:
+
+```bash
+$ FAB_DEBUG=1 fab check --root ./missing --threshold 0.5 --json
+{"command":"check","status":"error","error":{"message":"...","code":"SCORE_FILE_MISSING","stack":"Error: ...\n    at ..."}}
+```
+
+Without `--debug`, `error.stack` is omitted to keep envelopes compact for
+agent context budgets.
+
+---
+
+## For command authors
+
+The CLI envelope module exports four helpers (in `src/cli/json-envelope.ts`):
+
+| Helper | When to use |
+|--------|------------|
+| `emitOk(command, data, opts?)` | Success path. Exits 0. |
+| `emitDomainFailure(command, data, opts?)` | Tool ran, found a domain failure. `data` must include `ok: false`. Exits 1. |
+| `emitError(command, error, opts?)` | Infrastructure / runtime failure. `error` is `{message, code?}`. Exits 1. |
+| `emitTopLevelError(err, argv?)` | Catch-all for the top-level `parseAsync().catch()`. Routes through `emitError`. |
+
+All four exit the process. Each writes the envelope only when `--json` is set;
+in text mode they exit silently after the action's existing `console.log` /
+`console.error` calls.
+
+The `FabError` class lets command code throw with a `code` and optional
+`runRoot` that the top-level handler will surface in the envelope.
+
+---
+
+## Shipping
+
+This document is part of the published package — it must remain accurate as
+new commands land. CI gates (added in #26 — taxonomy-conformance lint) verify
+that no command emits `status: "error"` for an expected domain failure.

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "docs/run-root-contract.md",
     "docs/persona-yaml-reference.md",
     "docs/lisa-mcp.md",
+    "docs/cli-json-output.md",
     "docs/for-qa-engineers.md",
     "docs/executive-brief.md",
     "docs/value-proposition.md",

--- a/src/cli/__test-helpers__/cli-runner.test.ts
+++ b/src/cli/__test-helpers__/cli-runner.test.ts
@@ -1,0 +1,62 @@
+import { runFab, parseSingleEnvelope, extractFabFraming } from './cli-runner';
+
+describe('cli-runner harness', () => {
+  it('runs fab --version and captures stdout + exit code', async () => {
+    const r = await runFab(['--version'], { timeoutMs: 10_000 });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(r.stderr).toBe('');
+    expect(r.timedOut).toBe(false);
+  });
+
+  it('runs fab --help and exits 0', async () => {
+    const r = await runFab(['--help'], { timeoutMs: 10_000 });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Synthetic Test Fabric CLI');
+  });
+
+  it('captures non-zero exit on unknown command', async () => {
+    const r = await runFab(['nonexistent-command'], { timeoutMs: 10_000 });
+    expect(r.exitCode).not.toBe(0);
+  });
+});
+
+describe('parseSingleEnvelope', () => {
+  it('parses a single JSON object', () => {
+    const obj = parseSingleEnvelope('{"command":"status","status":"ok","data":{"ok":true}}');
+    expect(obj).toMatchObject({ command: 'status', status: 'ok' });
+  });
+
+  it('throws on empty input', () => {
+    expect(() => parseSingleEnvelope('')).toThrow(/empty output/);
+  });
+
+  it('throws on non-JSON input', () => {
+    expect(() => parseSingleEnvelope('[fab smoke] 3/5 passed')).toThrow(/JSON\.parse failed/);
+  });
+
+  it('throws on multiple JSON objects (extra bytes)', () => {
+    expect(() => parseSingleEnvelope('{"a":1}\n{"b":2}')).toThrow(/JSON\.parse failed/);
+  });
+});
+
+describe('extractFabFraming', () => {
+  it('extracts only lines starting with [fab ...]', () => {
+    const stdout = [
+      '[fab smoke] Run root: /tmp/foo',
+      'random adapter log',
+      '[fab smoke] → SEED',
+      'more noise',
+      '[fab smoke] Passed.',
+    ].join('\n');
+    expect(extractFabFraming(stdout)).toEqual([
+      '[fab smoke] Run root: /tmp/foo',
+      '[fab smoke] → SEED',
+      '[fab smoke] Passed.',
+    ]);
+  });
+
+  it('returns empty array when no framing present', () => {
+    expect(extractFabFraming('just text\nno framing')).toEqual([]);
+  });
+});

--- a/src/cli/__test-helpers__/cli-runner.ts
+++ b/src/cli/__test-helpers__/cli-runner.ts
@@ -1,0 +1,111 @@
+// Test-only helper: spawn the fab CLI as a subprocess and capture stdout/stderr separately.
+// Excluded from dist via tsconfig (`**/__test-helpers__/**`).
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+export interface RunFabOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  input?: string;
+}
+
+export interface RunFabResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TSX_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+const FAB_SRC = path.join(REPO_ROOT, 'src', 'cli', 'fab.ts');
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Spawn `tsx src/cli/fab.ts <args>` as a subprocess. Captures stdout, stderr, and exit code
+ * separately so tests can assert stdout-purity (only one JSON envelope on stdout when --json
+ * is set; progress lines on stderr).
+ */
+export async function runFab(args: string[], opts: RunFabOptions = {}): Promise<RunFabResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const startedAt = Date.now();
+
+  return new Promise<RunFabResult>((resolve, reject) => {
+    const child = spawn(TSX_BIN, [FAB_SRC, ...args], {
+      cwd: opts.cwd ?? process.cwd(),
+      env: { ...process.env, ...opts.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      // Escalate to SIGKILL if still alive after 2s
+      setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2_000);
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr,
+        exitCode,
+        signal,
+        durationMs: Date.now() - startedAt,
+        timedOut,
+      });
+    });
+
+    if (opts.input !== undefined) {
+      child.stdin.write(opts.input);
+    }
+    child.stdin.end();
+  });
+}
+
+/**
+ * Parse stdout as a single JSON envelope. Throws if not exactly one parseable JSON object.
+ * Used by --json round-trip tests to enforce the stdout-purity contract.
+ */
+export function parseSingleEnvelope(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error('Expected one JSON envelope on stdout, got empty output');
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed;
+  } catch (err) {
+    throw new Error(
+      `Expected one JSON envelope on stdout, JSON.parse failed: ${(err as Error).message}\n` +
+      `Stdout (${trimmed.length} chars): ${trimmed.slice(0, 500)}${trimmed.length > 500 ? '…' : ''}`
+    );
+  }
+}
+
+/**
+ * Extract lines from stdout that begin with the CLI's own framing prefix `[fab ...]`.
+ * Used by backward-compat snapshot tests to focus on the CLI's framing
+ * (the bit at risk from stderr-redirect refactor) rather than the noisy loop body.
+ */
+export function extractFabFraming(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .filter((line) => /^\[fab\b/.test(line));
+}

--- a/src/cli/__test-helpers__/fixtures/noisy.config.ts
+++ b/src/cli/__test-helpers__/fixtures/noisy.config.ts
@@ -1,0 +1,123 @@
+// Test fixture: stub config where one of the adapters emits console.log noise
+// inside a method. Used by the adapter-pollution regression test in json-mode.test.ts.
+
+import type {
+  AppAdapter,
+  SimulationAdapter,
+  ScoringAdapter,
+  FeedbackAdapter,
+  MemoryAdapter,
+  BrowserAdapter,
+  Reporter,
+  ScenarioPlanner,
+  SeededEntity,
+  AppHealthResult,
+  SimulationRunResult,
+  BrowserRunResult,
+  FabricReport,
+  ScenarioPlan,
+} from '../../../adapters';
+import type { FabricScore } from '../../../score';
+import type { FabricFeedback } from '../../../feedback';
+import type { RecorderInput } from '../../../recorder';
+import type { FabricConfig } from '../../types';
+
+export const NOISE_LINE_ADAPTER = 'NOISE_FROM_ADAPTER_console_log';
+export const NOISE_LINE_REPORTER = 'NOISE_FROM_REPORTER_console_log';
+export const NOISE_LINE_DIRECT_STDOUT = 'NOISE_FROM_ADAPTER_process_stdout_write';
+
+const STUB_SCORE: FabricScore = {
+  simulationId: 'sim-noisy-001',
+  generatedAt: '2026-01-01T00:00:00Z',
+  overall: 0.85,
+  dimensions: {
+    persona_realism: 0.9,
+    coverage_delta: 0.7,
+    fixture_health: 1.0,
+    discovery_yield: 0.6,
+    regression_health: 0.95,
+    flow_coverage: 0.85,
+  },
+  details: {},
+};
+
+class NoisyAppAdapter implements AppAdapter {
+  async seed(): Promise<SeededEntity[]> {
+    // The realistic source of stdout contamination: an adapter that writes to
+    // stdout for human progress display.
+    console.log(NOISE_LINE_ADAPTER);
+    process.stdout.write(NOISE_LINE_DIRECT_STDOUT + '\n');
+    return [];
+  }
+  async reset(): Promise<void> {}
+  async validateEnvironment(): Promise<AppHealthResult> { return { healthy: true, errors: [], warnings: [] }; }
+  async verify(): Promise<void> {}
+  async importRun(): Promise<void> {}
+}
+
+class StubSimulationAdapter implements SimulationAdapter {
+  async run(): Promise<SimulationRunResult> {
+    return { simulationId: 'sim-noisy-001', ticksCompleted: 0, behaviorEventsWritten: 0 };
+  }
+  async exportEntities(): Promise<void> {}
+  async clean(): Promise<void> {}
+}
+
+class StubScoringAdapter implements ScoringAdapter {
+  async score(): Promise<FabricScore> { return STUB_SCORE; }
+}
+
+class StubFeedbackAdapter implements FeedbackAdapter {
+  async feedback(): Promise<FabricFeedback> {
+    return {
+      loopId: 'noisy-loop',
+      iteration: 1,
+      generatedAt: '2026-01-01T00:00:00Z',
+      summary: 'noisy',
+      personaAdjustments: [],
+      scenarioRecommendation: null,
+      regressionFindings: [],
+    } as unknown as FabricFeedback;
+  }
+}
+
+class StubMemoryAdapter implements MemoryAdapter {
+  migrate(): void {}
+  writeEvent(_dbPath: string, _event: RecorderInput): void {}
+  resolveEntity(): SeededEntity | null { return null; }
+  listEntities(): SeededEntity[] { return []; }
+}
+
+class StubBrowserAdapter implements BrowserAdapter {
+  async runSpecs(opts: { iterRoot: string; project: string }): Promise<BrowserRunResult> {
+    return { passed: 0, failed: 0, total: 0, resultsPath: `${opts.iterRoot}/stub-results.json` };
+  }
+}
+
+class NoisyReporter implements Reporter {
+  async report(_score: FabricScore, _iterRoot: string): Promise<FabricReport> {
+    console.log(NOISE_LINE_REPORTER);
+    return { format: 'console', content: 'noisy report' };
+  }
+}
+
+class StubScenarioPlanner implements ScenarioPlanner {
+  async plan(_score: FabricScore, _iterRoot: string): Promise<ScenarioPlan> {
+    return { scenarioName: 'stub_scenario', rationale: 'stub', personaAdjustments: [] };
+  }
+}
+
+const config: FabricConfig = {
+  adapters: {
+    app:        new NoisyAppAdapter(),
+    simulation: new StubSimulationAdapter(),
+    scoring:    new StubScoringAdapter(),
+    feedback:   new StubFeedbackAdapter(),
+    memory:     new StubMemoryAdapter(),
+    browser:    new StubBrowserAdapter(),
+    reporters:  [new NoisyReporter()],
+    planner:    new StubScenarioPlanner(),
+  },
+};
+
+export default config;

--- a/src/cli/__test-helpers__/fixtures/stub.config.ts
+++ b/src/cli/__test-helpers__/fixtures/stub.config.ts
@@ -1,0 +1,113 @@
+// Test fixture: minimal FabricConfig with no-op adapters.
+// Used by backward-compat snapshot tests to exercise the CLI without
+// real adapter side effects. NOT shipped (excluded via `**/__test-helpers__/**`).
+
+import type {
+  AppAdapter,
+  SimulationAdapter,
+  ScoringAdapter,
+  FeedbackAdapter,
+  MemoryAdapter,
+  BrowserAdapter,
+  Reporter,
+  ScenarioPlanner,
+  SeededEntity,
+  AppHealthResult,
+  SimulationRunResult,
+  BrowserRunResult,
+  FabricReport,
+  ScenarioPlan,
+} from '../../../adapters';
+import type { FabricScore } from '../../../score';
+import type { FabricFeedback } from '../../../feedback';
+import type { RecorderInput } from '../../../recorder';
+import type { FabricConfig } from '../../types';
+
+const STUB_SCORE: FabricScore = {
+  simulationId: 'sim-stub-001',
+  generatedAt: '2026-01-01T00:00:00Z',
+  overall: 0.85,
+  dimensions: {
+    persona_realism: 0.9,
+    coverage_delta: 0.7,
+    fixture_health: 1.0,
+    discovery_yield: 0.6,
+    regression_health: 0.95,
+    flow_coverage: 0.85,
+  },
+  details: {},
+};
+
+class StubAppAdapter implements AppAdapter {
+  async seed(): Promise<SeededEntity[]> { return []; }
+  async reset(): Promise<void> {}
+  async validateEnvironment(): Promise<AppHealthResult> { return { healthy: true, errors: [], warnings: [] }; }
+  async verify(): Promise<void> {}
+  async importRun(): Promise<void> {}
+}
+
+class StubSimulationAdapter implements SimulationAdapter {
+  async run(): Promise<SimulationRunResult> {
+    return { simulationId: 'sim-stub-001', ticksCompleted: 0, behaviorEventsWritten: 0 };
+  }
+  async exportEntities(): Promise<void> {}
+  async clean(): Promise<void> {}
+}
+
+class StubScoringAdapter implements ScoringAdapter {
+  async score(): Promise<FabricScore> { return STUB_SCORE; }
+}
+
+class StubFeedbackAdapter implements FeedbackAdapter {
+  async feedback(): Promise<FabricFeedback> {
+    return {
+      loopId: 'stub-loop',
+      iteration: 1,
+      generatedAt: '2026-01-01T00:00:00Z',
+      summary: 'stub',
+      personaAdjustments: [],
+      scenarioRecommendation: null,
+      regressionFindings: [],
+    } as unknown as FabricFeedback;
+  }
+}
+
+class StubMemoryAdapter implements MemoryAdapter {
+  migrate(): void {}
+  writeEvent(_dbPath: string, _event: RecorderInput): void {}
+  resolveEntity(): SeededEntity | null { return null; }
+  listEntities(): SeededEntity[] { return []; }
+}
+
+class StubBrowserAdapter implements BrowserAdapter {
+  async runSpecs(opts: { iterRoot: string; project: string }): Promise<BrowserRunResult> {
+    return { passed: 0, failed: 0, total: 0, resultsPath: `${opts.iterRoot}/stub-results.json` };
+  }
+}
+
+class StubReporter implements Reporter {
+  async report(_score: FabricScore, _iterRoot: string): Promise<FabricReport> {
+    return { format: 'console', content: 'stub report' };
+  }
+}
+
+class StubScenarioPlanner implements ScenarioPlanner {
+  async plan(_score: FabricScore, _iterRoot: string): Promise<ScenarioPlan> {
+    return { scenarioName: 'stub_scenario', rationale: 'stub', personaAdjustments: [] };
+  }
+}
+
+const config: FabricConfig = {
+  adapters: {
+    app:        new StubAppAdapter(),
+    simulation: new StubSimulationAdapter(),
+    scoring:    new StubScoringAdapter(),
+    feedback:   new StubFeedbackAdapter(),
+    memory:     new StubMemoryAdapter(),
+    browser:    new StubBrowserAdapter(),
+    reporters:  [new StubReporter()],
+    planner:    new StubScenarioPlanner(),
+  },
+};
+
+export default config;

--- a/src/cli/fab.ts
+++ b/src/cli/fab.ts
@@ -23,7 +23,24 @@ import { installStdoutGuard } from './stdout-guard';
 // ---------------------------------------------------------------------------
 
 detectModesFromArgv();
-if (isJsonMode()) installStdoutGuard();
+if (isJsonMode()) {
+  installStdoutGuard();
+  // Special-case --help / --version: commander writes help/version text to
+  // stdout (which the guard just redirected) then calls exitOverride, which
+  // would leave stdout empty in --json mode and violate the contract.
+  // Pre-handle them with a minimal envelope before commander runs.
+  const argvAfterScript = process.argv.slice(2);
+  const wantsVersion = argvAfterScript.includes('--version') || argvAfterScript.includes('-V');
+  const wantsHelp = argvAfterScript.includes('--help') || argvAfterScript.includes('-h');
+  if (wantsVersion) {
+    emitOk('version', { version: '0.1.0' });
+  }
+  if (wantsHelp) {
+    emitOk('help', {
+      message: 'fab help is intended for human reading. Run without --json to see the full help text.',
+    });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: every command accepts --json and --debug
@@ -41,6 +58,12 @@ program
   .name('fab')
   .description('Synthetic Test Fabric CLI — autonomous QA loop')
   .version('0.1.0')
+  // Global --json / --debug also accepted at program level so callers can put
+  // the flag before OR after the subcommand: `fab --json seed` or `fab seed --json`.
+  // Both positions are honored by detectModesFromArgv (raw argv scan); these
+  // declarations just keep commander from rejecting the flag at the program scope.
+  .option('--json', 'Emit a machine-readable JSON envelope on stdout')
+  .option('--debug', 'Include stack traces in error envelopes')
   // Make commander throw on parse / unknown-option / missing-required-option errors
   // so the top-level catch can emit a JSON envelope when --json is set.
   // Help / version are still allowed to exit 0 normally.

--- a/src/cli/fab.ts
+++ b/src/cli/fab.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -7,18 +7,54 @@ import * as path from 'path';
 import { FabricOrchestrator } from '../orchestrator';
 import { resolveLoopPaths, makeLoopId } from '../run-root';
 import { loadFabricConfig } from './load-config';
+import {
+  detectModesFromArgv,
+  emitOk,
+  emitDomainFailure,
+  emitError,
+  emitTopLevelError,
+  isJsonMode,
+} from './json-envelope';
+import { installStdoutGuard } from './stdout-guard';
+
+// ---------------------------------------------------------------------------
+// JSON-mode setup — must run BEFORE commander parses so unknown-command /
+// missing-required-option errors still emit a JSON envelope when --json is set.
+// ---------------------------------------------------------------------------
+
+detectModesFromArgv();
+if (isJsonMode()) installStdoutGuard();
+
+// ---------------------------------------------------------------------------
+// Helper: every command accepts --json and --debug
+// ---------------------------------------------------------------------------
+
+function withJsonOptions<T extends Command>(cmd: T): T {
+  cmd.addOption(new Option('--json', 'Emit a machine-readable JSON envelope on stdout').default(false));
+  cmd.addOption(new Option('--debug', 'Include stack traces in error envelopes').default(false));
+  return cmd;
+}
 
 const program = new Command();
 
 program
   .name('fab')
   .description('Synthetic Test Fabric CLI — autonomous QA loop')
-  .version('0.1.0');
+  .version('0.1.0')
+  // Make commander throw on parse / unknown-option / missing-required-option errors
+  // so the top-level catch can emit a JSON envelope when --json is set.
+  // Help / version are still allowed to exit 0 normally.
+  .exitOverride((err) => {
+    if (err.code === 'commander.help' || err.code === 'commander.helpDisplayed' || err.code === 'commander.version') {
+      process.exit(0);
+    }
+    throw err;
+  });
 
 // ---------------------------------------------------------------------------
 // orchestrate — full autonomous loop
 // ---------------------------------------------------------------------------
-program
+withJsonOptions(program
   .command('orchestrate')
   .description('Run the full SEED→VERIFY→RUN→ANALYZE→GENERATE_FLOWS→TEST→SCORE→FEEDBACK loop')
   .option('--iterations <n>', 'Number of loop iterations', parseInt, 1)
@@ -30,12 +66,12 @@ program
   .option('--root <dir>', 'Persistent loop root directory (created if absent)')
   .option('--live-llm', 'Enable live LLM calls during simulation')
   .option('--allow-regression-failures', 'Continue to SCORE even when regression flows fail')
-  .option('--config <path>', 'Path to fabric.config.ts (default: ./fabric.config.ts)')
+  .option('--config <path>', 'Path to fabric.config.ts (default: ./fabric.config.ts)'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const d = config.defaults ?? {};
     const orchestrator = new FabricOrchestrator(config.adapters);
-    await orchestrator.run({
+    const score = await orchestrator.run({
       iterations:               opts.iterations               ?? d.iterations               ?? 1,
       ticks:                    opts.ticks                    ?? d.ticks                    ?? 5,
       seekers:                  opts.seekers                  ?? d.seekers                  ?? 2,
@@ -46,12 +82,13 @@ program
       liveLlm:                  opts.liveLlm                  ?? d.liveLlm                  ?? false,
       allowRegressionFailures:  opts.allowRegressionFailures  ?? d.allowRegressionFailures  ?? true,
     });
+    emitOk('orchestrate', { score: score.overall, iterations: opts.iterations }, { runRoot: opts.root });
   });
 
 // ---------------------------------------------------------------------------
 // fresh — one-shot run root
 // ---------------------------------------------------------------------------
-program
+withJsonOptions(program
   .command('fresh')
   .description('One-shot fresh run: seed → verify → [flows] → [score+feedback]')
   .option('--flows', 'Run Playwright flows after seeding')
@@ -62,7 +99,7 @@ program
   .option('--seekers <n>', 'Seeker count', parseInt, 2)
   .option('--employers <n>', 'Employer count', parseInt, 1)
   .option('--employees <n>', 'Employee count', parseInt, 0)
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const explicitRoot = !!opts.root;
@@ -73,6 +110,9 @@ program
     fs.mkdirSync(path.dirname(iterPaths.lisaDbPath), { recursive: true });
 
     let success = false;
+    let flowsResult: { passed: number; failed: number; total: number } | null = null;
+    let scoreResult: number | null = null;
+
     try {
       console.log(`[fab fresh] Run root: ${runRoot}`);
 
@@ -94,12 +134,14 @@ program
           project: 'flows',
           allowFailures: false,
         });
+        flowsResult = { passed: result.passed, failed: result.failed, total: result.total };
         console.log(`[fab fresh] flows: ${result.passed}/${result.total} passed`);
       }
 
       if (opts.plan) {
         console.log('[fab fresh] → SCORE');
         const score = await config.adapters.scoring.score(iterPaths.iterRoot);
+        scoreResult = score.overall;
         console.log('[fab fresh] → FEEDBACK');
         await config.adapters.feedback.feedback(iterPaths.iterRoot, {
           score,
@@ -121,17 +163,25 @@ program
         fs.rmSync(runRoot, { recursive: true, force: true });
       }
     }
+
+    emitOk('fresh', {
+      root: runRoot,
+      keep: opts.keep ?? false,
+      explicitRoot,
+      flows: flowsResult,
+      score: scoreResult,
+    }, { runRoot });
   });
 
 // ---------------------------------------------------------------------------
 // smoke — fastest handoff check
 // ---------------------------------------------------------------------------
-program
+withJsonOptions(program
   .command('smoke')
   .description('Fastest handoff check: seed → verify → one bounded smoke flow')
   .option('--root <dir>', 'Use a specific run root directory')
   .option('--keep', 'Keep run root after completion')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const explicitRoot = !!opts.root;
@@ -142,6 +192,8 @@ program
     fs.mkdirSync(path.dirname(iterPaths.lisaDbPath), { recursive: true });
 
     let success = false;
+    let result: { passed: number; failed: number; total: number } | null = null;
+
     try {
       console.log(`[fab smoke] Run root: ${runRoot}`);
 
@@ -156,12 +208,13 @@ program
       await config.adapters.app.verify(iterPaths.iterRoot);
 
       console.log('[fab smoke] → SMOKE FLOW');
-      const result = await config.adapters.browser.runSpecs({
+      const r = await config.adapters.browser.runSpecs({
         iterRoot: iterPaths.iterRoot,
         project: 'smoke',
         allowFailures: false,
       });
-      console.log(`[fab smoke] ${result.passed}/${result.total} passed`);
+      result = { passed: r.passed, failed: r.failed, total: r.total };
+      console.log(`[fab smoke] ${r.passed}/${r.total} passed`);
 
       success = true;
       console.log('[fab smoke] Passed.');
@@ -172,13 +225,15 @@ program
         fs.rmSync(runRoot, { recursive: true, force: true });
       }
     }
+
+    emitOk('smoke', { root: runRoot, keep: opts.keep ?? false, explicitRoot, flows: result }, { runRoot });
   });
 
 // ---------------------------------------------------------------------------
 // Primitive commands — operate on an explicit run root
 // ---------------------------------------------------------------------------
 
-program
+withJsonOptions(program
   .command('seed')
   .description('Seed simulation fixtures into a run root')
   .requiredOption('--root <dir>', 'Run root directory')
@@ -186,7 +241,7 @@ program
   .option('--seekers <n>', 'Seeker count', parseInt, 2)
   .option('--employers <n>', 'Employer count', parseInt, 1)
   .option('--employees <n>', 'Employee count', parseInt, 0)
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
@@ -199,27 +254,29 @@ program
       scenarioName: opts.scenario,
     });
     console.log(`[fab seed] Done. Root: ${opts.root}`);
+    emitOk('seed', { root: opts.root }, { runRoot: opts.root });
   });
 
-program
+withJsonOptions(program
   .command('verify')
   .description('Fail-closed fixture verification')
   .requiredOption('--root <dir>', 'Run root directory')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
     await config.adapters.app.verify(iterPaths.iterRoot);
     console.log('[fab verify] OK');
+    emitOk('verify', { root: opts.root }, { runRoot: opts.root });
   });
 
-program
+withJsonOptions(program
   .command('flows')
   .description('Run Playwright flows against an existing run root')
   .requiredOption('--root <dir>', 'Run root directory')
   .option('--grep <pattern>', 'Filter specs by name pattern')
   .option('--project <name>', 'Playwright project name', 'flows')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
@@ -230,14 +287,23 @@ program
       grep: opts.grep,
     });
     console.log(`[fab flows] ${result.passed}/${result.total} passed`);
-    if (result.failed > 0) process.exit(1);
+    if (result.failed > 0) {
+      // Domain failure: tool ran successfully, found failing flows.
+      emitDomainFailure('flows', {
+        ok: false,
+        passed: result.passed,
+        failed: result.failed,
+        total: result.total,
+      }, { runRoot: opts.root });
+    }
+    emitOk('flows', { ok: true, passed: result.passed, failed: result.failed, total: result.total }, { runRoot: opts.root });
   });
 
-program
+withJsonOptions(program
   .command('score')
   .description('Compute fabric score from an existing run root')
   .requiredOption('--root <dir>', 'Run root directory')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
@@ -246,19 +312,21 @@ program
       await r.report(score, iterPaths.iterRoot).catch(() => {});
     }
     console.log(`[fab score] Overall: ${score.overall}`);
+    emitOk('score', { overall: score.overall, dimensions: score.dimensions }, { runRoot: opts.root });
   });
 
-program
+withJsonOptions(program
   .command('feedback')
   .description('Generate feedback JSON from an existing run root')
   .requiredOption('--root <dir>', 'Run root directory')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
     if (!fs.existsSync(iterPaths.fabricScorePath)) {
-      console.error('[fab feedback] fabric-score.json not found — run `fab score` first');
-      process.exit(1);
+      const msg = `[fab feedback] fabric-score.json not found — run \`fab score\` first`;
+      console.error(msg);
+      emitError('feedback', { message: msg, code: 'SCORE_FILE_MISSING' }, { runRoot: opts.root });
     }
     const score = JSON.parse(fs.readFileSync(iterPaths.fabricScorePath, 'utf8'));
     await config.adapters.feedback.feedback(iterPaths.iterRoot, {
@@ -268,13 +336,14 @@ program
       previousIterRoot: null,
     });
     console.log('[fab feedback] Done.');
+    emitOk('feedback', { root: opts.root }, { runRoot: opts.root });
   });
 
-program
+withJsonOptions(program
   .command('analyze')
   .description('Extract discovered screen paths from behavior events')
   .requiredOption('--root <dir>', 'Run root directory')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const config = await loadFabricConfig(opts.config);
     const iterPaths = resolveLoopPaths(opts.root, 1);
@@ -284,6 +353,7 @@ program
       allowFailures: true,
     });
     console.log('[fab analyze] Done.');
+    emitOk('analyze', { root: opts.root }, { runRoot: opts.root });
   });
 
 // ---------------------------------------------------------------------------
@@ -292,32 +362,36 @@ program
 
 const baseline = program.command('baseline').description('Manage visual regression baselines');
 
-baseline
+withJsonOptions(baseline
   .command('list')
   .description('List all baselines with last-updated timestamp')
   .option('--baseline-dir <dir>', 'Baseline directory (default: .fab-baselines)')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const { listBaselines } = await import('../visual-regression');
     const dir = opts.baselineDir ?? await resolveBaselineDir(opts.config);
     const baselines = listBaselines(dir);
     if (baselines.length === 0) {
       console.log('[fab baseline list] No baselines found.');
-      return;
+      emitOk('baseline-list', { baselineDir: dir, baselines: [] });
     }
     console.log(`\nBaselines in ${dir}:\n`);
     for (const b of baselines) {
       console.log(`  ${b.name.padEnd(40)} ${b.updatedAt.toLocaleString()}`);
     }
     console.log();
+    emitOk('baseline-list', {
+      baselineDir: dir,
+      baselines: baselines.map((b) => ({ name: b.name, updatedAt: b.updatedAt.toISOString() })),
+    });
   });
 
-baseline
+withJsonOptions(baseline
   .command('update <flow>')
   .description('Accept the current screenshot as the new baseline for <flow>')
   .requiredOption('--root <dir>', 'Run root containing the current screenshot')
   .option('--baseline-dir <dir>', 'Baseline directory (default: .fab-baselines)')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (flow: string, opts) => {
     const { updateBaseline } = await import('../visual-regression');
     const dir = opts.baselineDir ?? await resolveBaselineDir(opts.config);
@@ -326,22 +400,27 @@ baseline
     if (!fs.existsSync(currentPng)) {
       console.error(`[fab baseline update] No current screenshot at ${currentPng}`);
       console.error('  Run the flow first, then update the baseline.');
-      process.exit(1);
+      emitError('baseline-update', {
+        message: `No current screenshot at ${currentPng}`,
+        code: 'SCREENSHOT_MISSING',
+      }, { runRoot: opts.root });
     }
     updateBaseline(dir, flow, currentPng);
     console.log(`[fab baseline update] Baseline updated for '${flow}' → ${dir}`);
+    emitOk('baseline-update', { flow, baselineDir: dir, source: currentPng }, { runRoot: opts.root });
   });
 
-baseline
+withJsonOptions(baseline
   .command('reset')
   .description('Delete all baselines — next run will re-capture from scratch')
   .option('--baseline-dir <dir>', 'Baseline directory (default: .fab-baselines)')
-  .option('--config <path>', 'Path to fabric.config.ts')
+  .option('--config <path>', 'Path to fabric.config.ts'))
   .action(async (opts) => {
     const { resetBaselines } = await import('../visual-regression');
     const dir = opts.baselineDir ?? await resolveBaselineDir(opts.config);
     resetBaselines(dir);
     console.log(`[fab baseline reset] All baselines removed from ${dir}`);
+    emitOk('baseline-reset', { baselineDir: dir });
   });
 
 async function resolveBaselineDir(configPath?: string): Promise<string> {
@@ -357,27 +436,39 @@ async function resolveBaselineDir(configPath?: string): Promise<string> {
 // check — CI score gate
 // ---------------------------------------------------------------------------
 
-program
+withJsonOptions(program
   .command('check')
   .description('Fail with exit code 1 if fabric score is below threshold (use in CI)')
   .requiredOption('--root <dir>', 'Run root directory containing fabric-score.json')
   .option('--threshold <n>', 'Minimum passing score (0–10)', parseFloat, 8.0)
-  .option('--config <path>', 'Path to fabric.config.ts (not required for this command)')
+  .option('--config <path>', 'Path to fabric.config.ts (not required for this command)'))
   .action(async (opts) => {
     const scorePath = path.join(resolveLoopPaths(opts.root, 1).fabricScorePath);
     if (!fs.existsSync(scorePath)) {
+      // Infrastructure error: the command can't run because the input file is missing.
       console.error(`[fab check] fabric-score.json not found at ${scorePath}`);
       console.error('  Run `fab score --root <dir>` first.');
-      process.exit(1);
+      emitError('check', {
+        message: `fabric-score.json not found at ${scorePath}`,
+        code: 'SCORE_FILE_MISSING',
+      }, { runRoot: opts.root });
     }
     const score = JSON.parse(fs.readFileSync(scorePath, 'utf8'));
     const { assertScoreThreshold } = await import('../reporters/gate');
     try {
       assertScoreThreshold(score, opts.threshold);
       console.log(`[fab check] ✅ Score ${score.overall.toFixed(1)} ≥ threshold ${opts.threshold.toFixed(1)}`);
+      emitOk('check', { ok: true, score: score.overall, threshold: opts.threshold }, { runRoot: opts.root });
     } catch (err: unknown) {
-      console.error(`[fab check] ❌ ${(err as Error).message}`);
-      process.exit(1);
+      const message = (err as Error).message;
+      // Domain failure: command ran successfully and found the score below threshold.
+      console.error(`[fab check] ❌ ${message}`);
+      emitDomainFailure('check', {
+        ok: false,
+        score: score.overall,
+        threshold: opts.threshold,
+        message,
+      }, { runRoot: opts.root });
     }
   });
 
@@ -385,9 +476,14 @@ program
 // Parse
 // ---------------------------------------------------------------------------
 
-program.parseAsync(process.argv).catch((err: Error) => {
-  console.error(`fab: ${err.message}`);
-  process.exit(1);
+program.parseAsync(process.argv).catch((err: Error & { code?: string }) => {
+  // Commander parse errors already wrote their message to stderr.
+  // For other errors in non-JSON mode, surface them to stderr too.
+  const isCommanderError = typeof err.code === 'string' && err.code.startsWith('commander.');
+  if (!isJsonMode() && !isCommanderError) {
+    console.error(`fab: ${err.message}`);
+  }
+  emitTopLevelError(err, process.argv);
 });
 
 function makeTempRoot(prefix: string): string {

--- a/src/cli/json-envelope.test.ts
+++ b/src/cli/json-envelope.test.ts
@@ -1,0 +1,58 @@
+// Unit tests for the envelope helpers themselves.
+// Integration tests (CLI subprocess round-trips) live in *.cli.test.ts files.
+
+import {
+  detectModesFromArgv,
+  setJsonMode,
+  isJsonMode,
+  setDebugMode,
+  isDebugMode,
+  FabError,
+} from './json-envelope';
+
+describe('detectModesFromArgv', () => {
+  beforeEach(() => {
+    setJsonMode(false);
+    setDebugMode(false);
+    delete process.env.FAB_DEBUG;
+  });
+
+  it('detects --json anywhere in argv', () => {
+    detectModesFromArgv(['node', 'fab.ts', 'smoke', '--json', '--root', '/tmp']);
+    expect(isJsonMode()).toBe(true);
+  });
+
+  it('leaves --json off when not present', () => {
+    detectModesFromArgv(['node', 'fab.ts', 'smoke', '--root', '/tmp']);
+    expect(isJsonMode()).toBe(false);
+  });
+
+  it('detects --debug anywhere in argv', () => {
+    detectModesFromArgv(['node', 'fab.ts', 'check', '--debug']);
+    expect(isDebugMode()).toBe(true);
+  });
+
+  it('honors FAB_DEBUG=1 env even without --debug flag', () => {
+    process.env.FAB_DEBUG = '1';
+    detectModesFromArgv(['node', 'fab.ts', 'smoke']);
+    expect(isDebugMode()).toBe(true);
+  });
+});
+
+describe('FabError', () => {
+  it('carries an optional code', () => {
+    const e = new FabError('boom', { code: 'SAMPLE_CODE' });
+    expect(e.message).toBe('boom');
+    expect(e.code).toBe('SAMPLE_CODE');
+    expect(e.name).toBe('FabError');
+  });
+
+  it('carries an optional runRoot', () => {
+    const e = new FabError('boom', { runRoot: '/tmp/foo' });
+    expect(e.runRoot).toBe('/tmp/foo');
+  });
+
+  it('is instanceof Error', () => {
+    expect(new FabError('x')).toBeInstanceOf(Error);
+  });
+});

--- a/src/cli/json-envelope.ts
+++ b/src/cli/json-envelope.ts
@@ -1,0 +1,170 @@
+/**
+ * CLI JSON output envelope and outcome taxonomy for `fab`.
+ *
+ * Three uniform outcome categories — see docs/cli-json-output.md for the full
+ * caller contract. In short:
+ *
+ *   1. Success                       → status:"ok",    data: <command-shape> | {ok:true,...},  exit 0
+ *   2. Domain check failed (ran ok)  → status:"ok",    data: {ok:false, ...details},           exit 1
+ *   3. Infrastructure / runtime err  → status:"error", error: {message, code?, stack?},        exit 1
+ *
+ * Automation must key off BOTH the process exit code AND the envelope fields:
+ *   - `status`   describes infrastructure outcome ("did the tool itself succeed?")
+ *   - `data.ok`  describes domain outcome where applicable ("did the input pass the check?")
+ *
+ * In `--json` mode, stdout contains exactly one JSON object on every invocation.
+ * In default text mode, no envelope is written; callers see the existing human-readable framing.
+ */
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+export interface OkEnvelope {
+  command: string;
+  status: 'ok';
+  data: unknown;
+  runRoot?: string;
+  /** Suggested follow-up command string (e.g. "fab inspect --root ..."). */
+  next?: string;
+}
+
+export interface ErrorEnvelope {
+  command: string;
+  status: 'error';
+  error: {
+    message: string;
+    code?: string;
+    /** Only included when FAB_DEBUG=1 or --debug. */
+    stack?: string;
+  };
+  runRoot?: string;
+}
+
+export type FabResult = OkEnvelope | ErrorEnvelope;
+
+// ---------------------------------------------------------------------------
+// JSON-mode flag (set by detectJsonModeFromArgv before commander parses)
+// ---------------------------------------------------------------------------
+
+let _jsonMode = false;
+let _debugMode = false;
+
+export function setJsonMode(v: boolean): void { _jsonMode = v; }
+export function isJsonMode(): boolean { return _jsonMode; }
+
+export function setDebugMode(v: boolean): void { _debugMode = v; }
+export function isDebugMode(): boolean { return _debugMode; }
+
+/**
+ * Pre-commander argv scan. Sets the `--json` and `--debug` flags by inspecting
+ * raw process.argv so even commander parse failures (unknown command, missing
+ * required option) emit a JSON envelope when the caller asked for one.
+ *
+ * Also respects FAB_DEBUG=1 for stack-trace inclusion in error envelopes.
+ */
+export function detectModesFromArgv(argv: string[] = process.argv): void {
+  _jsonMode = argv.includes('--json');
+  _debugMode = argv.includes('--debug') || process.env.FAB_DEBUG === '1';
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Infrastructure / runtime error thrown from inside a command action.
+ * Caught by the top-level handler and emitted as an ErrorEnvelope.
+ */
+export class FabError extends Error {
+  readonly code?: string;
+  readonly runRoot?: string;
+  constructor(message: string, opts: { code?: string; runRoot?: string } = {}) {
+    super(message);
+    this.name = 'FabError';
+    this.code = opts.code;
+    this.runRoot = opts.runRoot;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emitters — each writes one envelope (when --json) and exits with the right code
+// ---------------------------------------------------------------------------
+
+// Lazy-imported so this module stays usable in unit tests that don't install the guard.
+function writeEnvelope(result: FabResult): void {
+  if (!_jsonMode) return;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { unsafeWriteStdout } = require('./stdout-guard') as typeof import('./stdout-guard');
+  unsafeWriteStdout(JSON.stringify(result) + '\n');
+}
+
+/** Success outcome (status:"ok"). Exits with code 0. */
+export function emitOk(
+  command: string,
+  data: unknown,
+  opts: { runRoot?: string; next?: string } = {},
+): never {
+  writeEnvelope({ command, status: 'ok', data, runRoot: opts.runRoot, next: opts.next });
+  process.exit(0);
+}
+
+/**
+ * Domain-failure outcome (status:"ok", data:{ok:false,...}). Exits with code 1.
+ *
+ * Use when the tool ran successfully but the input failed a check
+ * (e.g. `fab check` below threshold, `fab adapter validate` found errors,
+ *  `fab doctor` reported a fail-tier check).
+ */
+export function emitDomainFailure(
+  command: string,
+  data: { ok: false } & Record<string, unknown>,
+  opts: { runRoot?: string; next?: string } = {},
+): never {
+  writeEnvelope({ command, status: 'ok', data, runRoot: opts.runRoot, next: opts.next });
+  process.exit(1);
+}
+
+/**
+ * Infrastructure-error outcome (status:"error"). Exits with code 1 (or opts.exitCode).
+ *
+ * Use when the tool itself could not run (missing file, parse error, bad input,
+ * unexpected exception). Reserved STRICTLY for tool failures — domain check
+ * failures use emitDomainFailure.
+ */
+export function emitError(
+  command: string,
+  err: { message: string; code?: string; stack?: string },
+  opts: { runRoot?: string; exitCode?: number } = {},
+): never {
+  const errorPayload: ErrorEnvelope['error'] = { message: err.message };
+  if (err.code) errorPayload.code = err.code;
+  if (err.stack && _debugMode) errorPayload.stack = err.stack;
+  writeEnvelope({ command, status: 'error', error: errorPayload, runRoot: opts.runRoot });
+  process.exit(opts.exitCode ?? 1);
+}
+
+/**
+ * Top-level error handler for parseAsync().catch() and pre-commander failures.
+ * Tries to extract a command name from argv; falls back to "fab".
+ */
+export function emitTopLevelError(err: unknown, argv: string[] = process.argv): never {
+  const command = inferCommandFromArgv(argv);
+  if (err instanceof FabError) {
+    return emitError(command, { message: err.message, code: err.code, stack: err.stack }, { runRoot: err.runRoot });
+  }
+  if (err instanceof Error) {
+    return emitError(command, { message: err.message, stack: err.stack });
+  }
+  return emitError(command, { message: String(err) });
+}
+
+function inferCommandFromArgv(argv: string[]): string {
+  // argv[0] = node, argv[1] = fab.ts (or fab.js)
+  // First non-flag after the script is the command.
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a && !a.startsWith('-')) return a;
+  }
+  return 'fab';
+}

--- a/src/cli/json-mode.test.ts
+++ b/src/cli/json-mode.test.ts
@@ -69,7 +69,7 @@ describe('--json adapter-pollution regression', () => {
 });
 
 describe('--json detection from raw process.argv (pre-commander)', () => {
-  it('emits JSON error envelope on unknown command when --json is set', async () => {
+  it('emits JSON error envelope on unknown command when --json is set (after subcommand)', async () => {
     const r = await runFab(['nonexistent-command', '--json']);
     expect(r.exitCode).not.toBe(0);
     const env: any = parseSingleEnvelope(r.stdout);
@@ -91,6 +91,59 @@ describe('--json detection from raw process.argv (pre-commander)', () => {
     expect(r.exitCode).not.toBe(0);
     expect(r.stdout.trim()).toBe(''); // no JSON on stdout in text mode
     expect(r.stderr.length).toBeGreaterThan(0);
+  });
+
+  // Regression: --json must work whether placed before OR after the subcommand.
+  // Pre-fix, `fab --json seed` was rejected by commander as an unknown program-level option.
+  it('accepts --json BEFORE the subcommand (fab --json seed)', async () => {
+    const r = await runFab(['--json', 'seed']);  // missing required --root
+    expect(r.exitCode).not.toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.status).toBe('error');
+    expect(env.error.message).toMatch(/required option|--root/);
+  });
+
+  it('accepts --json BEFORE an unknown subcommand (fab --json nonexistent)', async () => {
+    const r = await runFab(['--json', 'nonexistent-command']);
+    expect(r.exitCode).not.toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.status).toBe('error');
+    expect(env.error.message).toBeDefined();
+  });
+});
+
+describe('--json with --version and --help', () => {
+  // Regression: --version / --help write to stdout via commander, which the
+  // stdout guard would have redirected, leaving stdout empty in --json mode
+  // and violating the "exactly one envelope" contract. Pre-handled now.
+  it('emits a version envelope on fab --version --json', async () => {
+    const r = await runFab(['--version', '--json']);
+    expect(r.exitCode).toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.command).toBe('version');
+    expect(env.status).toBe('ok');
+    expect(env.data.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('emits a help envelope on fab --help --json', async () => {
+    const r = await runFab(['--help', '--json']);
+    expect(r.exitCode).toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.command).toBe('help');
+    expect(env.status).toBe('ok');
+    expect(env.data.message).toMatch(/intended for human reading/);
+  });
+
+  it('still emits human-readable text on fab --version (no --json)', async () => {
+    const r = await runFab(['--version']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('still emits human-readable text on fab --help (no --json)', async () => {
+    const r = await runFab(['--help']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Synthetic Test Fabric CLI');
   });
 });
 

--- a/src/cli/json-mode.test.ts
+++ b/src/cli/json-mode.test.ts
@@ -1,0 +1,155 @@
+// Integration tests for --json mode:
+//   - Stdout-purity regression (adapter/reporter logs don't pollute the envelope)
+//   - Pre-commander parse error path (unknown command / missing required option still emits JSON)
+//   - Outcome taxonomy round-trip (success / domain failure / infra error)
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runFab, parseSingleEnvelope } from './__test-helpers__/cli-runner';
+import {
+  NOISE_LINE_ADAPTER,
+  NOISE_LINE_REPORTER,
+  NOISE_LINE_DIRECT_STDOUT,
+} from './__test-helpers__/fixtures/noisy.config';
+
+const STUB_CONFIG = path.resolve(__dirname, '__test-helpers__/fixtures/stub.config.ts');
+const NOISY_CONFIG = path.resolve(__dirname, '__test-helpers__/fixtures/noisy.config.ts');
+
+function tmpRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `fab-json-${prefix}-`));
+}
+
+describe('--json adapter-pollution regression', () => {
+  it('keeps stdout pure even when an adapter calls console.log and process.stdout.write', async () => {
+    const root = tmpRoot('pollution');
+    try {
+      const r = await runFab(['smoke', '--root', root, '--config', NOISY_CONFIG, '--keep', '--json']);
+      expect(r.exitCode).toBe(0);
+
+      // The adapter wrote noise via console.log and process.stdout.write.
+      // None of it should reach stdout when --json is set.
+      expect(r.stdout).not.toContain(NOISE_LINE_ADAPTER);
+      expect(r.stdout).not.toContain(NOISE_LINE_DIRECT_STDOUT);
+
+      // Stdout must be parseable as exactly one JSON envelope.
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.command).toBe('smoke');
+      expect(env.status).toBe('ok');
+
+      // The noise must still be visible to the user — on stderr.
+      expect(r.stderr).toContain(NOISE_LINE_ADAPTER);
+      expect(r.stderr).toContain(NOISE_LINE_DIRECT_STDOUT);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps stdout pure when a reporter calls console.log', async () => {
+    const root = tmpRoot('reporter-pollution');
+    try {
+      // The noisy reporter only fires from `score`, not `smoke`. Use score with a pre-written score file.
+      const iter = path.join(root, 'iter-001');
+      fs.mkdirSync(iter, { recursive: true });
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+        simulationId: 'x', generatedAt: '2026-01-01T00:00:00Z', overall: 0.85, dimensions: {}, details: {},
+      }));
+      const r = await runFab(['score', '--root', root, '--config', NOISY_CONFIG, '--json']);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain(NOISE_LINE_REPORTER);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.command).toBe('score');
+      expect(env.status).toBe('ok');
+      expect(r.stderr).toContain(NOISE_LINE_REPORTER);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('--json detection from raw process.argv (pre-commander)', () => {
+  it('emits JSON error envelope on unknown command when --json is set', async () => {
+    const r = await runFab(['nonexistent-command', '--json']);
+    expect(r.exitCode).not.toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.status).toBe('error');
+    expect(env.error.message).toBeDefined();
+  });
+
+  it('emits JSON error envelope on missing required option when --json is set', async () => {
+    // `seed` requires --root.
+    const r = await runFab(['seed', '--json']);
+    expect(r.exitCode).not.toBe(0);
+    const env: any = parseSingleEnvelope(r.stdout);
+    expect(env.status).toBe('error');
+    expect(env.error.message).toMatch(/required option|--root/);
+  });
+
+  it('keeps text-mode error format when --json is NOT set', async () => {
+    const r = await runFab(['nonexistent-command']);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout.trim()).toBe(''); // no JSON on stdout in text mode
+    expect(r.stderr.length).toBeGreaterThan(0);
+  });
+});
+
+describe('--json outcome taxonomy round-trips', () => {
+  it('success: status=ok, data carries command-specific shape, exit 0', async () => {
+    const root = tmpRoot('taxonomy-success');
+    try {
+      const iter = path.join(root, 'iter-001');
+      fs.mkdirSync(iter, { recursive: true });
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+        simulationId: 'x', generatedAt: '2026-01-01T00:00:00Z', overall: 0.85, dimensions: {}, details: {},
+      }));
+      const r = await runFab(['check', '--root', root, '--threshold', '0.5', '--json']);
+      expect(r.exitCode).toBe(0);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.status).toBe('ok');
+      expect(env.data.ok).toBe(true);
+      expect(env.data.score).toBe(0.85);
+      expect(env.data.threshold).toBe(0.5);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('domain failure: status=ok, data.ok=false, exit 1', async () => {
+    const root = tmpRoot('taxonomy-domain');
+    try {
+      const iter = path.join(root, 'iter-001');
+      fs.mkdirSync(iter, { recursive: true });
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+        simulationId: 'x', generatedAt: '2026-01-01T00:00:00Z', overall: 0.3, dimensions: {}, details: {},
+      }));
+      const r = await runFab(['check', '--root', root, '--threshold', '0.5', '--json']);
+      expect(r.exitCode).toBe(1);
+      const env: any = parseSingleEnvelope(r.stdout);
+      // Domain failure: tool ran successfully and found the score below threshold.
+      expect(env.status).toBe('ok');
+      expect(env.data.ok).toBe(false);
+      expect(env.data.score).toBe(0.3);
+      expect(env.data.threshold).toBe(0.5);
+      expect(env.data.message).toBeDefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('infrastructure error: status=error, no data, exit 1, error.code present', async () => {
+    const root = tmpRoot('taxonomy-infra');
+    try {
+      // No fabric-score.json → infra error, not a domain failure.
+      const r = await runFab(['check', '--root', root, '--threshold', '0.5', '--json']);
+      expect(r.exitCode).toBe(1);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.status).toBe('error');
+      expect(env.error.code).toBe('SCORE_FILE_MISSING');
+      expect(env.error.message).toMatch(/fabric-score\.json not found/);
+      expect((env as any).data).toBeUndefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/stdout-guard.test.ts
+++ b/src/cli/stdout-guard.test.ts
@@ -1,0 +1,85 @@
+import {
+  installStdoutGuard,
+  uninstallStdoutGuard,
+  unsafeWriteStdout,
+  isStdoutGuardInstalled,
+} from './stdout-guard';
+
+describe('stdout-guard', () => {
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    // Capture writes to both streams before the test (and before installing the guard).
+    stdoutChunks = [];
+    stderrChunks = [];
+    originalStdoutWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write;
+    originalStderrWrite = process.stderr.write.bind(process.stderr) as typeof process.stderr.write;
+
+    process.stdout.write = ((chunk: unknown): boolean => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: unknown): boolean => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    uninstallStdoutGuard();
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  });
+
+  it('starts uninstalled', () => {
+    expect(isStdoutGuardInstalled()).toBe(false);
+  });
+
+  it('redirects process.stdout.write to stderr after install', () => {
+    installStdoutGuard();
+    process.stdout.write('would-be-stdout');
+    expect(stdoutChunks).toEqual([]);
+    expect(stderrChunks).toContain('would-be-stdout');
+  });
+
+  it('redirects console.log to stderr after install', () => {
+    installStdoutGuard();
+    console.log('hello from adapter');
+    expect(stdoutChunks).toEqual([]);
+    expect(stderrChunks.join('')).toContain('hello from adapter');
+  });
+
+  it('redirects console.info and console.debug to stderr', () => {
+    installStdoutGuard();
+    console.info('info-line');
+    console.debug('debug-line');
+    expect(stdoutChunks).toEqual([]);
+    expect(stderrChunks.join('')).toContain('info-line');
+    expect(stderrChunks.join('')).toContain('debug-line');
+  });
+
+  it('unsafeWriteStdout reaches actual stdout even after install', () => {
+    installStdoutGuard();
+    unsafeWriteStdout('envelope-bytes');
+    expect(stdoutChunks).toContain('envelope-bytes');
+  });
+
+  it('uninstall restores original stdout.write', () => {
+    installStdoutGuard();
+    uninstallStdoutGuard();
+    process.stdout.write('back-to-stdout');
+    expect(stdoutChunks).toContain('back-to-stdout');
+  });
+
+  it('install is idempotent', () => {
+    installStdoutGuard();
+    installStdoutGuard();    // second call should be a no-op
+    expect(isStdoutGuardInstalled()).toBe(true);
+    process.stdout.write('check');
+    expect(stdoutChunks).toEqual([]);
+    expect(stderrChunks.join('')).toContain('check');
+  });
+});

--- a/src/cli/stdout-guard.ts
+++ b/src/cli/stdout-guard.ts
@@ -1,0 +1,91 @@
+/**
+ * Stdout-purity guard for `--json` mode.
+ *
+ * When `--json` is set, the CLI must emit exactly one JSON envelope on stdout.
+ * Adapter / reporter / orchestrator code calls `console.log` and `process.stdout.write`
+ * freely during normal operation — those writes would corrupt the envelope.
+ *
+ * This module intercepts stdout writes globally so they route to stderr instead,
+ * while exposing `unsafeWriteStdout()` for the CLI's own envelope emission.
+ *
+ * Install order: detectModesFromArgv() → installStdoutGuard() → commander.parse().
+ */
+
+import { format } from 'util';
+
+let _installed = false;
+let _originalStdoutWrite: typeof process.stdout.write | null = null;
+let _originalConsoleLog: typeof console.log | null = null;
+let _originalConsoleInfo: typeof console.info | null = null;
+let _originalConsoleDebug: typeof console.debug | null = null;
+
+/**
+ * Redirect all stdout writes to stderr. Idempotent.
+ *
+ * After this runs, `console.log()` from any source — adapter, reporter,
+ * orchestrator, third-party lib — emits to stderr instead of stdout.
+ *
+ * Use `unsafeWriteStdout()` to write to the original stdout (envelope emission).
+ */
+export function installStdoutGuard(): void {
+  if (_installed) return;
+  _installed = true;
+
+  _originalStdoutWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write;
+  _originalConsoleLog = console.log.bind(console);
+  _originalConsoleInfo = console.info.bind(console);
+  _originalConsoleDebug = console.debug.bind(console);
+
+  // Redirect process.stdout.write → process.stderr.write.
+  // Anything writing through Node's stdout stream (including console.log when
+  // it hasn't been further patched) ends up on stderr.
+  process.stdout.write = ((chunk: unknown, ...rest: unknown[]): boolean => {
+    return (process.stderr.write as (...args: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof process.stdout.write;
+
+  // Patch the common console methods directly too. Each writes via util.format
+  // → process.stderr.write so the patch doesn't depend on Node's internal
+  // console-to-stream wiring (which differs per method).
+  const writeStderr = (args: unknown[]): void => {
+    process.stderr.write(format(...args) + '\n');
+  };
+  console.log = (...args: unknown[]): void => writeStderr(args);
+  console.info = (...args: unknown[]): void => writeStderr(args);
+  console.debug = (...args: unknown[]): void => writeStderr(args);
+}
+
+/**
+ * Restore the original stdout.write and console methods. Idempotent.
+ *
+ * Tests use this to undo the patch between cases.
+ */
+export function uninstallStdoutGuard(): void {
+  if (!_installed) return;
+  _installed = false;
+  if (_originalStdoutWrite) process.stdout.write = _originalStdoutWrite;
+  if (_originalConsoleLog)  console.log  = _originalConsoleLog;
+  if (_originalConsoleInfo) console.info = _originalConsoleInfo;
+  if (_originalConsoleDebug) console.debug = _originalConsoleDebug;
+  _originalStdoutWrite = null;
+  _originalConsoleLog = null;
+  _originalConsoleInfo = null;
+  _originalConsoleDebug = null;
+}
+
+/**
+ * Write to the original (un-redirected) stdout. The CLI's envelope emitter
+ * uses this so the JSON envelope reaches actual stdout even when the guard
+ * is installed.
+ */
+export function unsafeWriteStdout(s: string): void {
+  if (_originalStdoutWrite) {
+    _originalStdoutWrite(s);
+  } else {
+    process.stdout.write(s);
+  }
+}
+
+/** Test-only: report whether the guard is currently installed. */
+export function isStdoutGuardInstalled(): boolean {
+  return _installed;
+}

--- a/src/cli/text-mode.test.ts
+++ b/src/cli/text-mode.test.ts
@@ -1,0 +1,213 @@
+// Backward-compat regression tests: lock down the existing text-mode CLI framing
+// BEFORE the --json refactor. These assertions must continue to pass after #18 ships
+// — that proves we didn't accidentally break non-JSON output for existing users.
+//
+// Focus: lines beginning with `[fab ...]` (the CLI's own framing, the part at risk
+// from the stderr-redirect refactor). Body lines from the orchestrator/adapters are
+// out of scope here.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runFab, extractFabFraming } from './__test-helpers__/cli-runner';
+
+const STUB_CONFIG = path.resolve(__dirname, '__test-helpers__/fixtures/stub.config.ts');
+
+function makeRunRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `fab-text-mode-${prefix}-`));
+}
+
+function redactRoot(line: string, root: string): string {
+  return line.split(root).join('<RUN_ROOT>');
+}
+
+describe('text-mode framing (backward-compat snapshots)', () => {
+  describe('fab smoke', () => {
+    it('emits the expected framing on a clean stub run', async () => {
+      const root = makeRunRoot('smoke');
+      try {
+        const r = await runFab(['smoke', '--root', root, '--config', STUB_CONFIG, '--keep']);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout).map((l) => redactRoot(l, root));
+        expect(framing).toEqual([
+          '[fab smoke] Run root: <RUN_ROOT>',
+          '[fab smoke] → SEED',
+          '[fab smoke] → VERIFY',
+          '[fab smoke] → SMOKE FLOW',
+          '[fab smoke] 0/0 passed',
+          '[fab smoke] Passed.',
+        ]);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab fresh', () => {
+    it('emits the expected framing without --flows / --plan', async () => {
+      const root = makeRunRoot('fresh');
+      try {
+        const r = await runFab(['fresh', '--root', root, '--config', STUB_CONFIG, '--keep']);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout).map((l) => redactRoot(l, root));
+        expect(framing).toEqual([
+          '[fab fresh] Run root: <RUN_ROOT>',
+          '[fab fresh] → SEED',
+          '[fab fresh] → VERIFY',
+          '[fab fresh] Done. Root: <RUN_ROOT>',
+        ]);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('emits FLOWS framing with --flows', async () => {
+      const root = makeRunRoot('fresh-flows');
+      try {
+        const r = await runFab(['fresh', '--root', root, '--config', STUB_CONFIG, '--keep', '--flows']);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout).map((l) => redactRoot(l, root));
+        expect(framing).toContain('[fab fresh] → FLOWS');
+        expect(framing).toContain('[fab fresh] flows: 0/0 passed');
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('emits SCORE / FEEDBACK framing with --plan', async () => {
+      const root = makeRunRoot('fresh-plan');
+      try {
+        const r = await runFab(['fresh', '--root', root, '--config', STUB_CONFIG, '--keep', '--plan']);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout).map((l) => redactRoot(l, root));
+        expect(framing).toContain('[fab fresh] → SCORE');
+        expect(framing).toContain('[fab fresh] → FEEDBACK');
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab seed', () => {
+    it('emits Done line with the run root', async () => {
+      const root = makeRunRoot('seed');
+      try {
+        const r = await runFab(['seed', '--root', root, '--config', STUB_CONFIG]);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout).map((l) => redactRoot(l, root));
+        expect(framing).toEqual(['[fab seed] Done. Root: <RUN_ROOT>']);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab verify', () => {
+    it('emits OK on successful verify', async () => {
+      const root = makeRunRoot('verify');
+      try {
+        // Seed first so iter-001 exists with the verifier-expected layout.
+        await runFab(['seed', '--root', root, '--config', STUB_CONFIG]);
+        const r = await runFab(['verify', '--root', root, '--config', STUB_CONFIG]);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout);
+        expect(framing).toEqual(['[fab verify] OK']);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab score', () => {
+    it('emits the overall score line', async () => {
+      const root = makeRunRoot('score');
+      try {
+        await runFab(['seed', '--root', root, '--config', STUB_CONFIG]);
+        const r = await runFab(['score', '--root', root, '--config', STUB_CONFIG]);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout);
+        expect(framing).toEqual(['[fab score] Overall: 0.85']);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab check', () => {
+    it('emits the ✅ pass line when score meets threshold', async () => {
+      const root = makeRunRoot('check-pass');
+      try {
+        const iter = path.join(root, 'iter-001');
+        fs.mkdirSync(iter, { recursive: true });
+        fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+          simulationId: 'sim-001', generatedAt: '2026-01-01T00:00:00Z',
+          overall: 0.85, dimensions: {}, details: {},
+        }));
+        const r = await runFab(['check', '--root', root, '--threshold', '0.5']);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout);
+        expect(framing).toHaveLength(1);
+        expect(framing[0]).toMatch(/^\[fab check\] ✅ Score 0\.\d+ ≥ threshold 0\.\d+$/);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('emits the ❌ fail line when score is below threshold', async () => {
+      const root = makeRunRoot('check-fail');
+      try {
+        const iter = path.join(root, 'iter-001');
+        fs.mkdirSync(iter, { recursive: true });
+        fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+          simulationId: 'sim-001', generatedAt: '2026-01-01T00:00:00Z',
+          overall: 0.3, dimensions: {}, details: {},
+        }));
+        const r = await runFab(['check', '--root', root, '--threshold', '0.5']);
+        // Currently exits 1 with ❌ message via console.error + process.exit(1).
+        // After #18, must still exit 1 and still emit ❌ to stderr or stdout.
+        expect(r.exitCode).toBe(1);
+        const allOutput = r.stdout + r.stderr;
+        const framing = allOutput
+          .split('\n')
+          .filter((l) => /^\[fab check\]/.test(l));
+        expect(framing).toHaveLength(1);
+        expect(framing[0]).toMatch(/^\[fab check\] ❌/);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab feedback', () => {
+    it('emits the not-found error message when fabric-score.json is absent', async () => {
+      const root = makeRunRoot('feedback-missing');
+      try {
+        const r = await runFab(['feedback', '--root', root, '--config', STUB_CONFIG]);
+        expect(r.exitCode).toBe(1);
+        const allOutput = r.stdout + r.stderr;
+        const framing = allOutput
+          .split('\n')
+          .filter((l) => /^\[fab feedback\]/.test(l));
+        expect(framing.length).toBeGreaterThanOrEqual(1);
+        expect(framing[0]).toMatch(/fabric-score\.json not found/);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fab baseline list', () => {
+    it('emits the no-baselines line on an empty dir', async () => {
+      const root = makeRunRoot('baseline-empty');
+      try {
+        const r = await runFab(['baseline', 'list', '--baseline-dir', root, '--config', STUB_CONFIG]);
+        expect(r.exitCode).toBe(0);
+        const framing = extractFabFraming(r.stdout);
+        expect(framing).toEqual(['[fab baseline list] No baselines found.']);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/run-root.test.ts
+++ b/src/run-root.test.ts
@@ -1,0 +1,157 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  detectRootKind,
+  resolveLoopRoot,
+  resolveIterRoot,
+  resolveLoopPaths,
+} from './run-root';
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fab-rr-'));
+}
+
+function rm(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('detectRootKind', () => {
+  it('throws on non-existent path', () => {
+    expect(() => detectRootKind('/tmp/definitely-does-not-exist-' + Date.now())).toThrow(/does not exist/);
+  });
+
+  it('returns "loop" on an empty directory (loop intent)', () => {
+    const d = tmp();
+    try { expect(detectRootKind(d)).toBe('loop'); } finally { rm(d); }
+  });
+
+  it('returns "loop" when iter-NNN subdirs exist', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.mkdirSync(path.join(d, 'iter-002'));
+      expect(detectRootKind(d)).toBe('loop');
+    } finally { rm(d); }
+  });
+
+  it('returns "loop" when only a current symlink exists', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.symlinkSync('iter-001', path.join(d, 'current'));
+      expect(detectRootKind(d)).toBe('loop');
+    } finally { rm(d); }
+  });
+
+  it('returns "iteration" when fabric-score.json is at root', () => {
+    const d = tmp();
+    try {
+      fs.writeFileSync(path.join(d, 'fabric-score.json'), '{}');
+      expect(detectRootKind(d)).toBe('iteration');
+    } finally { rm(d); }
+  });
+
+  it('returns "ambiguous" when both shapes present', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.writeFileSync(path.join(d, 'fabric-score.json'), '{}');
+      expect(detectRootKind(d)).toBe('ambiguous');
+    } finally { rm(d); }
+  });
+
+  it('returns "unknown" for a non-empty dir that matches nothing', () => {
+    const d = tmp();
+    try {
+      fs.writeFileSync(path.join(d, 'random.txt'), 'x');
+      fs.mkdirSync(path.join(d, 'subdir'));
+      expect(detectRootKind(d)).toBe('unknown');
+    } finally { rm(d); }
+  });
+});
+
+describe('resolveLoopRoot', () => {
+  it('returns loopRoot unchanged when given a loopRoot', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      expect(resolveLoopRoot(d)).toBe(d);
+    } finally { rm(d); }
+  });
+
+  it('returns parent when given an iterRoot', () => {
+    const d = tmp();
+    try {
+      const iter = path.join(d, 'iter-001');
+      fs.mkdirSync(iter);
+      // To make iter look like an iteration root in isolation, drop a fabric-score.json there
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), '{}');
+      expect(resolveLoopRoot(iter)).toBe(d);
+    } finally { rm(d); }
+  });
+
+  it('throws on ambiguous input', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.writeFileSync(path.join(d, 'fabric-score.json'), '{}');
+      expect(() => resolveLoopRoot(d)).toThrow(/ambiguous/);
+    } finally { rm(d); }
+  });
+
+  it('throws on unknown input', () => {
+    const d = tmp();
+    try {
+      fs.writeFileSync(path.join(d, 'random.txt'), 'x');
+      expect(() => resolveLoopRoot(d)).toThrow(/does not look like/);
+    } finally { rm(d); }
+  });
+});
+
+describe('resolveIterRoot', () => {
+  it('returns iterRoot unchanged when given an iterRoot', () => {
+    const d = tmp();
+    try {
+      const iter = path.join(d, 'iter-002');
+      fs.mkdirSync(iter);
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), '{}');
+      expect(resolveIterRoot(iter)).toBe(iter);
+    } finally { rm(d); }
+  });
+
+  it('returns latest iter when given a loopRoot with multiple iters', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.mkdirSync(path.join(d, 'iter-002'));
+      fs.mkdirSync(path.join(d, 'iter-003'));
+      expect(resolveIterRoot(d)).toBe(path.join(d, 'iter-003'));
+    } finally { rm(d); }
+  });
+
+  it('returns specific iter when iteration arg is given', () => {
+    const d = tmp();
+    try {
+      fs.mkdirSync(path.join(d, 'iter-001'));
+      fs.mkdirSync(path.join(d, 'iter-002'));
+      expect(resolveIterRoot(d, 1)).toBe(path.join(d, 'iter-001'));
+    } finally { rm(d); }
+  });
+
+  it('returns iter-001 placeholder for an empty loop dir', () => {
+    const d = tmp();
+    try {
+      expect(resolveIterRoot(d)).toBe(path.join(d, 'iter-001'));
+    } finally { rm(d); }
+  });
+});
+
+describe('resolveLoopPaths (existing — sanity)', () => {
+  it('still works for callers that pass loopRoot + iterNum', () => {
+    const paths = resolveLoopPaths('/tmp/foo', 1);
+    expect(paths.iterRoot).toBe('/tmp/foo/iter-001');
+    expect(paths.fabricScorePath).toBe('/tmp/foo/iter-001/fabric-score.json');
+  });
+});

--- a/src/run-root.ts
+++ b/src/run-root.ts
@@ -30,6 +30,103 @@ export function makeLoopId(): string {
   return `fabric-loop-${Date.now()}`;
 }
 
+// ---------------------------------------------------------------------------
+// Root-kind detection and normalization (foundation for #19 / #20)
+// ---------------------------------------------------------------------------
+
+export type RootKind = 'loop' | 'iteration' | 'ambiguous' | 'unknown';
+
+const ITER_DIR_RE = /^iter-\d{3}$/;
+
+/**
+ * Classify a directory as a loopRoot, an iterRoot, ambiguous, or unknown.
+ *
+ * Decision rules (applied in order):
+ *  1. Path doesn't exist → throws (caller treats as infrastructure error)
+ *  2. Has both `iter-NNN/` subdirs AND `fabric-score.json` → "ambiguous"
+ *  3. Has any `iter-NNN/` subdir, OR a `current` symlink, OR is an empty directory → "loop"
+ *  4. Has `fabric-score.json` directly inside → "iteration"
+ *  5. Exists with files but matches none of the above → "unknown"
+ */
+export function detectRootKind(dir: string): RootKind {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`detectRootKind: path does not exist: ${dir}`);
+  }
+  const stat = fs.statSync(dir);
+  if (!stat.isDirectory()) {
+    return 'unknown';
+  }
+
+  const entries = fs.readdirSync(dir);
+  const hasIterDirs = entries.some((e) => {
+    if (!ITER_DIR_RE.test(e)) return false;
+    try { return fs.statSync(path.join(dir, e)).isDirectory(); } catch { return false; }
+  });
+  const hasCurrentSymlink = (() => {
+    try { return fs.lstatSync(path.join(dir, 'current')).isSymbolicLink(); } catch { return false; }
+  })();
+  const hasScoreFile = entries.includes('fabric-score.json');
+
+  // Rule 2: both shapes present → ambiguous
+  if ((hasIterDirs || hasCurrentSymlink) && hasScoreFile) return 'ambiguous';
+  // Rule 3: loop shape
+  if (hasIterDirs || hasCurrentSymlink) return 'loop';
+  // Rule 3 cont'd: empty dir is loop intent (caller likely just `mkdir`'d)
+  if (entries.length === 0) return 'loop';
+  // Rule 4: iteration shape
+  if (hasScoreFile) return 'iteration';
+  // Rule 5: has files but matches nothing
+  return 'unknown';
+}
+
+/**
+ * Accept a loopRoot or iterRoot path; return the loopRoot.
+ *
+ * If `input` is already a loop root (detected or explicit), returns it unchanged.
+ * If `input` is an iter root (e.g. `/foo/iter-002`), returns the parent.
+ *
+ * Throws on ambiguous or unknown inputs — callers should have classified first
+ * if they want to disambiguate.
+ */
+export function resolveLoopRoot(input: string): string {
+  const kind = detectRootKind(input);
+  switch (kind) {
+    case 'loop':       return input;
+    case 'iteration':  return path.dirname(input);
+    case 'ambiguous':  throw new Error(`resolveLoopRoot: path is ambiguous (looks like both loop and iter): ${input}`);
+    case 'unknown':    throw new Error(`resolveLoopRoot: path does not look like a loop or iter root: ${input}`);
+  }
+}
+
+/**
+ * Accept a loopRoot or iterRoot path; return the iterRoot to inspect.
+ *
+ * - If `input` is a loop root: returns iter at `iteration` (default: latest existing
+ *   iter-NNN, or iter-001 if none exist yet).
+ * - If `input` is an iter root: returns it unchanged (the caller already picked one).
+ *
+ * Throws on ambiguous or unknown inputs.
+ */
+export function resolveIterRoot(input: string, iteration?: number): string {
+  const kind = detectRootKind(input);
+  switch (kind) {
+    case 'iteration':
+      return input;
+    case 'loop': {
+      if (iteration !== undefined) {
+        return path.join(input, `iter-${String(iteration).padStart(3, '0')}`);
+      }
+      const entries = fs.readdirSync(input).filter((e) => ITER_DIR_RE.test(e)).sort();
+      const latest = entries[entries.length - 1];
+      return latest ? path.join(input, latest) : path.join(input, 'iter-001');
+    }
+    case 'ambiguous':
+      throw new Error(`resolveIterRoot: path is ambiguous (looks like both loop and iter): ${input}`);
+    case 'unknown':
+      throw new Error(`resolveIterRoot: path does not look like a loop or iter root: ${input}`);
+  }
+}
+
 export const FABRIC_SEAL_FILE = '.fabric-sealed';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__test-helpers__/**"]
 }


### PR DESCRIPTION
## Summary

Foundation PR for the v0.4.0 epic. Lands `--json` on every `fab` command, the CLI outcome taxonomy, the stdout-purity guard, and shared root-normalization helpers that #19 / #20 depend on.

Closes #18. Blocks #19 / #20 / #21 / #22 / #23 / #24 / #27.

## What's in

### Stdout-purity contract (when `--json` is set)

- Stdout contains exactly one JSON envelope per invocation
- Adapter / reporter / orchestrator `console.log` + `process.stdout.write` route to stderr (global guard via `util.format`)
- `JSON.parse(stdout)` succeeds with no extra bytes

### CLI outcome taxonomy

Three uniform categories used by `check`, `doctor`, `adapter validate`, and any future domain-check command:

| Outcome | Envelope | Exit |
|---------|----------|------|
| Success | ` {status: "ok", data: <shape>}` | `0` |
| Domain check failed (tool ran, found problems) | `{status: "ok", data: {ok: false, ...}}` | `1` |
| Infrastructure / runtime error (tool couldn't run) | `{status: "error", error: {message, code?}}` (no `data`) | `1` |

### Other foundations

- `--json` detected from raw `process.argv` BEFORE commander parses, so unknown-command / missing-required-option still emit JSON
- `process.exit(1)` sites refactored to typed `FabError` / `emit*` helpers
- Top-level `parseAsync().catch()` routes through `emitTopLevelError`
- `commander.exitOverride()` lets parse errors hit our catch
- Shared `resolveLoopRoot` / `resolveIterRoot` / `detectRootKind` in `src/run-root.ts` (with `"ambiguous"` / `"unknown"` kinds for #20)

### Backward-compat

Snapshot tests pin every `[fab ...]` framing line for `smoke`, `fresh`, `seed`, `verify`, `score`, `check`, `feedback`, `baseline list`. These must keep passing for the lifetime of the epic.

### Caller contract (in `docs/cli-json-output.md`)

Automation must key off **both** the process exit code AND the envelope fields:
- `status` describes infrastructure outcome
- `data.ok` describes domain outcome where applicable
- Exit code must be checked even on `status: "ok"` (exit 1 + `status: "ok"` + `data.ok: false` is a normal domain failure)

## Test plan

- [x] `npm test` — 303/303 pass (47 new tests across 6 new files)
- [x] `npm run build` — clean
- [x] `npm run check:boundary` — pass
- [x] `npm run check:package-surface` — pass
- [x] `npm pack --dry-run` — `docs/cli-json-output.md` ships; `__test-helpers__` excluded
- [x] Backward-compat snapshots: every `[fab ...]` framing line preserved
- [x] Adapter-pollution regression: stub adapter calls `console.log` + `process.stdout.write` → stdout still contains exactly one envelope, noise routes to stderr
- [x] Reporter-pollution regression: same for reporter `console.log`
- [x] Pre-commander parse error path: `fab nonexistent --json` and `fab seed --json` (missing `--root`) both emit JSON error envelopes
- [x] Outcome taxonomy round-trips: success / domain failure (`check` below threshold) / infrastructure error (`check` with missing score file) — each maps to the right envelope shape

## Files changed

- **New**: `docs/cli-json-output.md`, `src/cli/json-envelope.{ts,test.ts}`, `src/cli/stdout-guard.{ts,test.ts}`, `src/cli/text-mode.test.ts`, `src/cli/json-mode.test.ts`, `src/run-root.test.ts`, `src/cli/__test-helpers__/`
- **Modified**: `src/cli/fab.ts` (refactor), `src/run-root.ts` (added helpers), `package.json` (files allowlist), `tsconfig.json` (exclude test helpers from dist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)