### PR TITLE
feat: fab adapter scaffold + scaffoldAdapter() (#22)

### DIFF
--- a/src/cli/adapter-scaffold.test.ts
+++ b/src/cli/adapter-scaffold.test.ts
@@ -1,0 +1,207 @@
+// Tests for `fab adapter scaffold` and the scaffoldAdapter() library export.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runFab, parseSingleEnvelope } from './__test-helpers__/cli-runner';
+import {
+  scaffoldAdapter,
+  ScaffoldAdapterError,
+  ADAPTER_TYPES,
+  ADAPTER_INTERFACES,
+  DEFAULT_ADAPTER_CLASS_NAMES,
+  renderAdapterStub,
+} from './init';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `fab-adapter-${prefix}-`));
+}
+function tmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fab-state-test-'));
+}
+
+describe('renderAdapterStub — covers all 8 types', () => {
+  it.each(ADAPTER_TYPES)('renders type %s with default class name', (type) => {
+    const content = renderAdapterStub(type);
+    const expectedClass = DEFAULT_ADAPTER_CLASS_NAMES[type];
+    const expectedIface = ADAPTER_INTERFACES[type];
+    expect(content).toMatch(new RegExp(`class ${expectedClass} implements ${expectedIface}\\b`));
+    expect(content).toMatch(/from 'synthetic-test-fabric'/);
+  });
+
+  it('respects custom className override', () => {
+    const content = renderAdapterStub('app', { className: 'AcmeAppAdapter' });
+    expect(content).toMatch(/class AcmeAppAdapter implements AppAdapter\b/);
+    expect(content).toMatch(/AcmeAppAdapter\.seed/);
+    expect(content).not.toMatch(/MyAppAdapter/);
+  });
+
+  it('respects custom packageName override', () => {
+    const content = renderAdapterStub('reporter', { pkg: '@my/forked-stf' });
+    expect(content).toMatch(/from '@my\/forked-stf'/);
+  });
+
+  it('reporter and planner stubs use real interface names (not casual labels)', () => {
+    expect(renderAdapterStub('reporter')).toMatch(/implements Reporter\b/);
+    expect(renderAdapterStub('planner')).toMatch(/implements ScenarioPlanner\b/);
+  });
+});
+
+describe('scaffoldAdapter — library', () => {
+  it('returns content without writing when --out omitted', () => {
+    const r = scaffoldAdapter('app');
+    expect(r.type).toBe('app');
+    expect(r.className).toBe('MyAppAdapter');
+    expect(r.interfaceName).toBe('AppAdapter');
+    expect(r.filePath).toBeNull();
+    expect(r.content).toMatch(/class MyAppAdapter/);
+  });
+
+  it('writes to --out when provided', () => {
+    const dir = tmpDir('write');
+    try {
+      const out = path.join(dir, 'src/MyApp.ts');
+      const r = scaffoldAdapter('app', { out });
+      expect(r.filePath).toBe(path.resolve(out));
+      expect(fs.existsSync(out)).toBe(true);
+      expect(fs.readFileSync(out, 'utf8')).toBe(r.content);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws ScaffoldAdapterError on unknown type', () => {
+    expect(() => scaffoldAdapter('not-a-type')).toThrow(ScaffoldAdapterError);
+    try { scaffoldAdapter('not-a-type'); }
+    catch (err) {
+      expect((err as ScaffoldAdapterError).code).toBe('UNKNOWN_ADAPTER_TYPE');
+      expect((err as ScaffoldAdapterError).message).toMatch(/Valid types: app, simulation/);
+    }
+  });
+
+  it('throws OUT_PATH_EXISTS when target file exists without force', () => {
+    const dir = tmpDir('conflict');
+    try {
+      const out = path.join(dir, 'a.ts');
+      scaffoldAdapter('app', { out });
+      expect(() => scaffoldAdapter('app', { out })).toThrow(ScaffoldAdapterError);
+      try { scaffoldAdapter('app', { out }); }
+      catch (err) {
+        expect((err as ScaffoldAdapterError).code).toBe('OUT_PATH_EXISTS');
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--force overwrites existing file', () => {
+    const dir = tmpDir('force');
+    try {
+      const out = path.join(dir, 'a.ts');
+      scaffoldAdapter('app', { out });
+      fs.writeFileSync(out, '// MUTATED');
+      scaffoldAdapter('app', { out, force: true });
+      expect(fs.readFileSync(out, 'utf8')).not.toBe('// MUTATED');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('fab adapter scaffold — CLI', () => {
+  it.each(ADAPTER_TYPES)('writes a stub file for type %s', async (type) => {
+    const dir = tmpDir(`cli-${type}`);
+    const stateDir = tmpStateDir();
+    try {
+      const out = path.join(dir, `Stub.ts`);
+      const r = await runFab(['adapter', 'scaffold', type, '--out', out, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(r.exitCode).toBe(0);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.command).toBe('adapter-scaffold');
+      expect(env.data.ok).toBe(true);
+      expect(env.data.type).toBe(type);
+      expect(env.data.interfaceName).toBe(ADAPTER_INTERFACES[type]);
+      expect(env.data.filePath).toBe(out);
+      expect(fs.existsSync(out)).toBe(true);
+      const content = fs.readFileSync(out, 'utf8');
+      expect(content).toMatch(new RegExp(`implements ${ADAPTER_INTERFACES[type]}\\b`));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--name overrides the class name', async () => {
+    const dir = tmpDir('cli-name');
+    const stateDir = tmpStateDir();
+    try {
+      const out = path.join(dir, 'a.ts');
+      const r = await runFab(['adapter', 'scaffold', 'app', '--out', out, '--name', 'AcmeAppAdapter', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.data.className).toBe('AcmeAppAdapter');
+      expect(fs.readFileSync(out, 'utf8')).toMatch(/class AcmeAppAdapter/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits UNKNOWN_ADAPTER_TYPE error envelope for invalid type', async () => {
+    const stateDir = tmpStateDir();
+    try {
+      const r = await runFab(['adapter', 'scaffold', 'gibberish', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(r.exitCode).toBe(1);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.status).toBe('error');
+      expect(env.error.code).toBe('UNKNOWN_ADAPTER_TYPE');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits OUT_PATH_EXISTS error envelope on conflict without --force', async () => {
+    const dir = tmpDir('cli-conflict');
+    const stateDir = tmpStateDir();
+    try {
+      const out = path.join(dir, 'a.ts');
+      await runFab(['adapter', 'scaffold', 'app', '--out', out, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      const r = await runFab(['adapter', 'scaffold', 'app', '--out', out, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(r.exitCode).toBe(1);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.error.code).toBe('OUT_PATH_EXISTS');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--force overwrites via CLI', async () => {
+    const dir = tmpDir('cli-force');
+    const stateDir = tmpStateDir();
+    try {
+      const out = path.join(dir, 'a.ts');
+      await runFab(['adapter', 'scaffold', 'app', '--out', out, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      fs.writeFileSync(out, '// MUTATED');
+      const r = await runFab(['adapter', 'scaffold', 'app', '--out', out, '--force', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(r.exitCode).toBe(0);
+      expect(fs.readFileSync(out, 'utf8')).not.toBe('// MUTATED');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('JSON envelope includes content when no --out (pipe mode)', async () => {
+    const stateDir = tmpStateDir();
+    try {
+      const r = await runFab(['adapter', 'scaffold', 'reporter', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(r.exitCode).toBe(0);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.data.filePath).toBeNull();
+      expect(env.data.content).toMatch(/class MyReporter implements Reporter/);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/fab.ts
+++ b/src/cli/fab.ts
@@ -22,7 +22,7 @@ import {
 import { installStdoutGuard } from './stdout-guard';
 import { recordCommand, readState, getStatePath } from './state';
 import type { LastRootKind } from './state';
-import { scaffoldProject, InitConflictError } from './init';
+import { scaffoldProject, InitConflictError, scaffoldAdapter, ScaffoldAdapterError, ADAPTER_TYPES } from './init';
 
 // ---------------------------------------------------------------------------
 // JSON-mode setup — must run BEFORE commander parses so unknown-command /
@@ -776,6 +776,67 @@ withJsonOptions(program
       dir: targetDir,
       filesCreated: result.filesCreated,
     }, { runRoot: targetDir, next: `cd ${targetDir} && edit src/adapters/*.ts then fab smoke` });
+  });
+
+// ---------------------------------------------------------------------------
+// adapter — per-adapter scaffolding utilities
+// ---------------------------------------------------------------------------
+
+const adapter = program.command('adapter').description('Per-adapter scaffolding + validation utilities');
+
+withJsonOptions(adapter
+  .command('scaffold <type>')
+  .description(`Generate a single adapter stub. Types: ${ADAPTER_TYPES.join(', ')}`)
+  .option('--out <path>', 'Output file path (defaults to stdout)')
+  .option('--name <ClassName>', 'Override the generated class name')
+  .option('--force', 'Overwrite an existing --out file'))
+  .action(async (type: string, opts) => {
+    let result;
+    try {
+      result = scaffoldAdapter(type, {
+        out: opts.out,
+        name: opts.name,
+        force: opts.force ?? false,
+      });
+    } catch (err) {
+      if (err instanceof ScaffoldAdapterError) {
+        console.error(`[fab adapter scaffold] ${err.message}`);
+        emitError('adapter-scaffold', { message: err.message, code: err.code });
+      }
+      throw err;
+    }
+
+    if (result.filePath) {
+      console.log(`[fab adapter scaffold] Created ${result.className} (implements ${result.interfaceName}) at ${result.filePath}`);
+    } else {
+      // No --out: pipe content to stdout. Tags as `[fab adapter scaffold]`
+      // line goes to stderr in --json mode (handled by stdout-guard);
+      // here we go to stderr explicitly so the pipe target sees only the file.
+      console.error(`[fab adapter scaffold] Generated ${result.className} (implements ${result.interfaceName}) — piping to stdout`);
+      // Bypass the guard: in --json mode emitOk will write the envelope to
+      // stdout, so for --json + no --out we put content in the envelope `data.content`
+      // instead of writing it to stdout directly.
+      if (!isJsonMode()) {
+        process.stdout.write(result.content);
+      }
+    }
+
+    recordCommand({
+      command: 'adapter-scaffold',
+      lastRoot: result.filePath ? path.dirname(result.filePath) : null,
+      lastRootKind: result.filePath ? 'persistent' : null,
+      lastPhase: 'SCAFFOLD',
+    });
+
+    emitOk('adapter-scaffold', {
+      ok: true,
+      type: result.type,
+      className: result.className,
+      interfaceName: result.interfaceName,
+      filePath: result.filePath,
+      // Include content in JSON envelope when no --out was given (pipe target).
+      content: result.filePath ? undefined : result.content,
+    }, { runRoot: result.filePath ?? undefined });
   });
 
 // ---------------------------------------------------------------------------

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,20 +1,217 @@
 /**
- * `fab init` — scaffolds a parseable `fabric.config.ts` plus stub adapters
- * into the target directory. The generated config is shaped to load
- * immediately via `loadFabricConfig()` so `fab doctor` (#24) and other
- * commands don't blow up the moment the user runs `fab init`.
+ * `fab init` and `fab adapter scaffold` — project + per-adapter scaffolders.
  *
- * Adapter stubs follow the real interface names exported from the package:
- * `AppAdapter`, `SimulationAdapter`, `ScoringAdapter`, `FeedbackAdapter`,
- * `MemoryAdapter`, `BrowserAdapter`, `Reporter`, `ScenarioPlanner`. Each
- * stub returns a no-op for methods the framework allows to be empty
- * (e.g., `reset`, `clean`, `validateEnvironment`) and throws
- * `new Error('TODO: implement <method>')` for required methods so
- * unimplemented adapters fail loudly rather than silently no-op.
+ * `scaffoldProject(opts)` writes a complete starter tree (fabric.config.ts +
+ * 8 adapter stubs + flows/.gitkeep). `scaffoldAdapter(type, opts)` writes a
+ * single adapter file for one of the 8 supported interfaces.
+ *
+ * Both commands share the same `ADAPTER_TEMPLATES` registry so the generated
+ * code is consistent across `fab init` and `fab adapter scaffold`.
+ *
+ * Stub policy: required interface methods throw `new Error('TODO: implement
+ * <method>')` so unimplemented adapters fail loudly. Optional methods (reset,
+ * clean, validateEnvironment, importRun) are no-ops by default.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Adapter type registry
+// ---------------------------------------------------------------------------
+
+/** All 8 adapter types fab knows how to scaffold. */
+export const ADAPTER_TYPES = [
+  'app', 'simulation', 'scoring', 'feedback',
+  'memory', 'browser', 'reporter', 'planner',
+] as const;
+
+export type AdapterType = typeof ADAPTER_TYPES[number];
+
+/** Interface name (in the synthetic-test-fabric package) for each adapter type. */
+export const ADAPTER_INTERFACES: Record<AdapterType, string> = {
+  app:        'AppAdapter',
+  simulation: 'SimulationAdapter',
+  scoring:    'ScoringAdapter',
+  feedback:   'FeedbackAdapter',
+  memory:     'MemoryAdapter',
+  browser:    'BrowserAdapter',
+  reporter:   'Reporter',
+  planner:    'ScenarioPlanner',
+};
+
+/** Default class name for each adapter type — used when --name not provided. */
+export const DEFAULT_ADAPTER_CLASS_NAMES: Record<AdapterType, string> = {
+  app:        'MyAppAdapter',
+  simulation: 'MySimulationAdapter',
+  scoring:    'MyScoringAdapter',
+  feedback:   'MyFeedbackAdapter',
+  memory:     'MyMemoryAdapter',
+  browser:    'MyBrowserAdapter',
+  reporter:   'MyReporter',
+  planner:    'MyScenarioPlanner',
+};
+
+export function isAdapterType(s: string): s is AdapterType {
+  return (ADAPTER_TYPES as readonly string[]).includes(s);
+}
+
+// ---------------------------------------------------------------------------
+// Template renderer
+// ---------------------------------------------------------------------------
+
+const TODO = (fqMethod: string) => `throw new Error('TODO: implement ${fqMethod}');`;
+
+/**
+ * Render the body of a stub adapter file for a given type + class name.
+ *
+ * Produces a complete, parseable TypeScript module that imports interface
+ * types from `pkg` and exports a class implementing the requested interface.
+ */
+export function renderAdapterStub(
+  type: AdapterType,
+  opts: { pkg?: string; className?: string } = {},
+): string {
+  const pkg = opts.pkg ?? 'synthetic-test-fabric';
+  const className = opts.className ?? DEFAULT_ADAPTER_CLASS_NAMES[type];
+  const iface = ADAPTER_INTERFACES[type];
+
+  switch (type) {
+    case 'app':
+      return `import type { ${iface}, SeededEntity, AppHealthResult } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async seed(_iterRoot: string, _config: { seekers: number; employers: number; employees: number; scenarioName?: string; personaAdjustmentsPath?: string }): Promise<SeededEntity[]> {
+    ${TODO(`${className}.seed`)}
+  }
+
+  async reset(_iterRoot: string): Promise<void> {
+    // No-op is acceptable here; remove app state created by seed() if your
+    // app keeps long-lived data between iterations.
+  }
+
+  async validateEnvironment(): Promise<AppHealthResult> {
+    return { healthy: true, errors: [], warnings: [] };
+  }
+
+  async verify(_iterRoot: string): Promise<void> {
+    ${TODO(`${className}.verify`)}
+  }
+
+  async importRun(_iterRoot: string, _dbUrl: string): Promise<void> {
+    // No-op is acceptable; only called when dbUrl is provided.
+  }
+}
+`;
+
+    case 'simulation':
+      return `import type { ${iface}, SeededEntity, SimulationRunResult } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async run(_iterRoot: string, _options: { ticks: number; liveLlm: boolean; simulationId?: string }): Promise<SimulationRunResult> {
+    ${TODO(`${className}.run`)}
+  }
+
+  async exportEntities(_iterRoot: string, _entities: SeededEntity[]): Promise<void> {
+    ${TODO(`${className}.exportEntities`)}
+  }
+
+  async clean(_iterRoot: string): Promise<void> {
+    // No-op is acceptable.
+  }
+}
+`;
+
+    case 'scoring':
+      return `import type { ${iface}, FabricScore } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async score(_iterRoot: string): Promise<FabricScore> {
+    ${TODO(`${className}.score`)}
+  }
+}
+`;
+
+    case 'feedback':
+      return `import type { ${iface}, FabricFeedback, FabricScore } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async feedback(_iterRoot: string, _options: { score: FabricScore; loopId: string; iteration: number; previousIterRoot: string | null }): Promise<FabricFeedback> {
+    ${TODO(`${className}.feedback`)}
+  }
+}
+`;
+
+    case 'memory':
+      return `import type { ${iface}, RecorderInput, SeededEntity } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  migrate(_dbPath: string): void {
+    ${TODO(`${className}.migrate`)}
+  }
+
+  writeEvent(_dbPath: string, _event: RecorderInput): void {
+    ${TODO(`${className}.writeEvent`)}
+  }
+
+  resolveEntity(_dbPath: string, _alias: string): SeededEntity | null {
+    return null;
+  }
+
+  listEntities(_dbPath: string, _simulationId: string): SeededEntity[] {
+    return [];
+  }
+}
+`;
+
+    case 'browser':
+      return `import type { ${iface}, BrowserRunResult, LlmProvider } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async runSpecs(_options: {
+    iterRoot: string;
+    project: string;
+    allowFailures: boolean;
+    grep?: string;
+    retryCount?: number;
+    retryDelayMs?: number;
+    quarantinedFlows?: string[];
+    llmProvider?: LlmProvider;
+  }): Promise<BrowserRunResult> {
+    ${TODO(`${className}.runSpecs`)}
+  }
+}
+`;
+
+    case 'reporter':
+      return `import type { ${iface}, FabricScore, FabricReport } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async report(_score: FabricScore, _iterRoot: string): Promise<FabricReport> {
+    return { format: 'console', content: '(stub reporter — replace with real implementation)' };
+  }
+}
+`;
+
+    case 'planner':
+      return `import type { ${iface}, FabricScore, ScenarioPlan } from '${pkg}';
+
+export class ${className} implements ${iface} {
+  async plan(_score: FabricScore, _iterRoot: string): Promise<ScenarioPlan> {
+    return {
+      scenarioName: 'baseline_browser_flow',
+      rationale: 'stub planner — always returns baseline; replace with your selection logic',
+      personaAdjustments: [],
+    };
+  }
+}
+`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// scaffoldProject (used by `fab init`)
+// ---------------------------------------------------------------------------
 
 export interface InitOptions {
   /** Target directory for scaffolding (defaults to process.cwd()). */
@@ -27,7 +224,7 @@ export interface InitOptions {
 
 export interface InitResult {
   filesCreated: string[];
-  filesSkipped: string[];     // files that already existed (only populated when not --force)
+  filesSkipped: string[];     // populated only when not --force and conflicts present
 }
 
 export class InitConflictError extends Error {
@@ -40,20 +237,20 @@ export class InitConflictError extends Error {
   }
 }
 
-interface FileSpec {
-  /** Relative path from the target dir. */
-  relPath: string;
-  /** File body. */
-  content: string;
-}
-
 export function scaffoldProject(opts: InitOptions = {}): InitResult {
   const targetDir = path.resolve(opts.dir ?? process.cwd());
   const pkg = opts.packageName ?? 'synthetic-test-fabric';
 
-  const files = generateFileSpecs(pkg);
+  // Build file list: fabric.config.ts + one stub per adapter type + flows/.gitkeep
+  const files: { relPath: string; content: string }[] = [
+    { relPath: 'fabric.config.ts', content: fabricConfigTemplate(pkg) },
+    ...ADAPTER_TYPES.map((type) => ({
+      relPath: `src/adapters/${DEFAULT_ADAPTER_CLASS_NAMES[type]}.ts`,
+      content: renderAdapterStub(type, { pkg }),
+    })),
+    { relPath: 'flows/.gitkeep', content: '' },
+  ];
 
-  // Check for conflicts before writing anything.
   const conflicts = files
     .map((f) => path.join(targetDir, f.relPath))
     .filter((p) => fs.existsSync(p));
@@ -61,8 +258,6 @@ export function scaffoldProject(opts: InitOptions = {}): InitResult {
     throw new InitConflictError(conflicts);
   }
 
-  // Write all files (atomic-ish: errors mid-batch leave partial state, but
-  // that's no worse than the conflict-check pattern).
   const filesCreated: string[] = [];
   for (const f of files) {
     const full = path.join(targetDir, f.relPath);
@@ -73,27 +268,6 @@ export function scaffoldProject(opts: InitOptions = {}): InitResult {
 
   return { filesCreated, filesSkipped: [] };
 }
-
-// ---------------------------------------------------------------------------
-// Template generation
-// ---------------------------------------------------------------------------
-
-function generateFileSpecs(pkg: string): FileSpec[] {
-  return [
-    { relPath: 'fabric.config.ts',                    content: fabricConfigTemplate(pkg) },
-    { relPath: 'src/adapters/MyAppAdapter.ts',        content: appAdapterStub(pkg) },
-    { relPath: 'src/adapters/MySimulationAdapter.ts', content: simulationAdapterStub(pkg) },
-    { relPath: 'src/adapters/MyScoringAdapter.ts',    content: scoringAdapterStub(pkg) },
-    { relPath: 'src/adapters/MyFeedbackAdapter.ts',   content: feedbackAdapterStub(pkg) },
-    { relPath: 'src/adapters/MyMemoryAdapter.ts',     content: memoryAdapterStub(pkg) },
-    { relPath: 'src/adapters/MyBrowserAdapter.ts',    content: browserAdapterStub(pkg) },
-    { relPath: 'src/adapters/MyReporter.ts',          content: reporterStub(pkg) },
-    { relPath: 'src/adapters/MyScenarioPlanner.ts',   content: scenarioPlannerStub(pkg) },
-    { relPath: 'flows/.gitkeep',                      content: '' },
-  ];
-}
-
-const TODO = (method: string) => `throw new Error('TODO: implement ${method}');`;
 
 function fabricConfigTemplate(pkg: string): string {
   return `// Generated by \`fab init\`. Wire your real adapters in src/adapters/ and customize this file.
@@ -124,140 +298,74 @@ export default config;
 `;
 }
 
-function appAdapterStub(pkg: string): string {
-  return `import type { AppAdapter, SeededEntity, AppHealthResult } from '${pkg}';
+// ---------------------------------------------------------------------------
+// scaffoldAdapter (used by `fab adapter scaffold <type>`)
+// ---------------------------------------------------------------------------
 
-export class MyAppAdapter implements AppAdapter {
-  async seed(_iterRoot: string, _config: { seekers: number; employers: number; employees: number; scenarioName?: string; personaAdjustmentsPath?: string }): Promise<SeededEntity[]> {
-    ${TODO('MyAppAdapter.seed')}
-  }
-
-  async reset(_iterRoot: string): Promise<void> {
-    // No-op is acceptable here; remove app state created by seed() if your
-    // app keeps long-lived data between iterations.
-  }
-
-  async validateEnvironment(): Promise<AppHealthResult> {
-    return { healthy: true, errors: [], warnings: [] };
-  }
-
-  async verify(_iterRoot: string): Promise<void> {
-    ${TODO('MyAppAdapter.verify')}
-  }
-
-  async importRun(_iterRoot: string, _dbUrl: string): Promise<void> {
-    // No-op is acceptable; only called when dbUrl is provided.
-  }
-}
-`;
+export interface ScaffoldAdapterOptions {
+  /** Output file path. If omitted, content is returned but not written. */
+  out?: string;
+  /** Class name for the generated stub. Defaults to DEFAULT_ADAPTER_CLASS_NAMES[type]. */
+  name?: string;
+  /** Package import path. Default 'synthetic-test-fabric'. */
+  packageName?: string;
+  /** Overwrite existing file at `out` instead of failing. */
+  force?: boolean;
 }
 
-function simulationAdapterStub(pkg: string): string {
-  return `import type { SimulationAdapter, SeededEntity, SimulationRunResult } from '${pkg}';
-
-export class MySimulationAdapter implements SimulationAdapter {
-  async run(_iterRoot: string, _options: { ticks: number; liveLlm: boolean; simulationId?: string }): Promise<SimulationRunResult> {
-    ${TODO('MySimulationAdapter.run')}
-  }
-
-  async exportEntities(_iterRoot: string, _entities: SeededEntity[]): Promise<void> {
-    ${TODO('MySimulationAdapter.exportEntities')}
-  }
-
-  async clean(_iterRoot: string): Promise<void> {
-    // No-op is acceptable.
-  }
-}
-`;
+export interface ScaffoldAdapterResult {
+  type: AdapterType;
+  className: string;
+  interfaceName: string;
+  content: string;
+  /** Absolute path the stub was written to, or null if `out` was omitted (stdout mode). */
+  filePath: string | null;
 }
 
-function scoringAdapterStub(pkg: string): string {
-  return `import type { ScoringAdapter, FabricScore } from '${pkg}';
-
-export class MyScoringAdapter implements ScoringAdapter {
-  async score(_iterRoot: string): Promise<FabricScore> {
-    ${TODO('MyScoringAdapter.score')}
+export class ScaffoldAdapterError extends Error {
+  readonly code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'ScaffoldAdapterError';
+    this.code = code;
   }
 }
-`;
-}
 
-function feedbackAdapterStub(pkg: string): string {
-  return `import type { FeedbackAdapter, FabricFeedback, FabricScore } from '${pkg}';
-
-export class MyFeedbackAdapter implements FeedbackAdapter {
-  async feedback(_iterRoot: string, _options: { score: FabricScore; loopId: string; iteration: number; previousIterRoot: string | null }): Promise<FabricFeedback> {
-    ${TODO('MyFeedbackAdapter.feedback')}
-  }
-}
-`;
-}
-
-function memoryAdapterStub(pkg: string): string {
-  return `import type { MemoryAdapter, RecorderInput, SeededEntity } from '${pkg}';
-
-export class MyMemoryAdapter implements MemoryAdapter {
-  migrate(_dbPath: string): void {
-    ${TODO('MyMemoryAdapter.migrate')}
+/**
+ * Generate a single adapter stub of the requested type.
+ *
+ * If `out` is provided, writes the file (refusing to overwrite without
+ * `force`). If `out` is omitted, returns the content for the caller to
+ * pipe to stdout / stash elsewhere.
+ */
+export function scaffoldAdapter(
+  type: string,
+  opts: ScaffoldAdapterOptions = {},
+): ScaffoldAdapterResult {
+  if (!isAdapterType(type)) {
+    throw new ScaffoldAdapterError(
+      `Unknown adapter type '${type}'. Valid types: ${ADAPTER_TYPES.join(', ')}`,
+      'UNKNOWN_ADAPTER_TYPE',
+    );
   }
 
-  writeEvent(_dbPath: string, _event: RecorderInput): void {
-    ${TODO('MyMemoryAdapter.writeEvent')}
+  const className = opts.name ?? DEFAULT_ADAPTER_CLASS_NAMES[type];
+  const content = renderAdapterStub(type, { pkg: opts.packageName, className });
+  const interfaceName = ADAPTER_INTERFACES[type];
+
+  let filePath: string | null = null;
+  if (opts.out !== undefined) {
+    const resolved = path.resolve(opts.out);
+    if (fs.existsSync(resolved) && !opts.force) {
+      throw new ScaffoldAdapterError(
+        `${resolved} already exists; pass --force to overwrite`,
+        'OUT_PATH_EXISTS',
+      );
+    }
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.writeFileSync(resolved, content);
+    filePath = resolved;
   }
 
-  resolveEntity(_dbPath: string, _alias: string): SeededEntity | null {
-    return null;
-  }
-
-  listEntities(_dbPath: string, _simulationId: string): SeededEntity[] {
-    return [];
-  }
-}
-`;
-}
-
-function browserAdapterStub(pkg: string): string {
-  return `import type { BrowserAdapter, BrowserRunResult, LlmProvider } from '${pkg}';
-
-export class MyBrowserAdapter implements BrowserAdapter {
-  async runSpecs(_options: {
-    iterRoot: string;
-    project: string;
-    allowFailures: boolean;
-    grep?: string;
-    retryCount?: number;
-    retryDelayMs?: number;
-    quarantinedFlows?: string[];
-    llmProvider?: LlmProvider;
-  }): Promise<BrowserRunResult> {
-    ${TODO('MyBrowserAdapter.runSpecs')}
-  }
-}
-`;
-}
-
-function reporterStub(pkg: string): string {
-  return `import type { Reporter, FabricScore, FabricReport } from '${pkg}';
-
-export class MyReporter implements Reporter {
-  async report(_score: FabricScore, _iterRoot: string): Promise<FabricReport> {
-    return { format: 'console', content: '(stub reporter — replace with real implementation)' };
-  }
-}
-`;
-}
-
-function scenarioPlannerStub(pkg: string): string {
-  return `import type { ScenarioPlanner, FabricScore, ScenarioPlan } from '${pkg}';
-
-export class MyScenarioPlanner implements ScenarioPlanner {
-  async plan(_score: FabricScore, _iterRoot: string): Promise<ScenarioPlan> {
-    return {
-      scenarioName: 'baseline_browser_flow',
-      rationale: 'stub planner — always returns baseline; replace with your selection logic',
-      personaAdjustments: [],
-    };
-  }
-}
-`;
+  return { type, className, interfaceName, content, filePath };
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,4 +71,21 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('per-adapter scaffolder (#22)', () => {
+    it.each([
+      'scaffoldAdapter',
+      'ScaffoldAdapterError',
+      'ScaffoldAdapterOptions',
+      'ScaffoldAdapterResult',
+      'renderAdapterStub',
+      'isAdapterType',
+      'AdapterType',
+      'ADAPTER_TYPES',
+      'ADAPTER_INTERFACES',
+      'DEFAULT_ADAPTER_CLASS_NAMES',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,21 @@ export type {
 // Project scaffolder (added in #21) — same library backs the `fab init` CLI.
 export { scaffoldProject, InitConflictError } from './cli/init';
 export type { InitOptions, InitResult } from './cli/init';
+// Per-adapter scaffolder (added in #22) — same library backs `fab adapter scaffold`.
+export {
+  scaffoldAdapter,
+  ScaffoldAdapterError,
+  renderAdapterStub,
+  isAdapterType,
+  ADAPTER_TYPES,
+  ADAPTER_INTERFACES,
+  DEFAULT_ADAPTER_CLASS_NAMES,
+} from './cli/init';
+export type {
+  AdapterType,
+  ScaffoldAdapterOptions,
+  ScaffoldAdapterResult,
+} from './cli/init';
 export type { FabricScore } from './score';
 export { parsePlaywrightResults, specFilenameToScreenPath } from './playwright-result';
 export type { PlaywrightAgentResult, PlaywrightFailedFlow } from './playwright-result';


### PR DESCRIPTION
## Summary

Per-adapter scaffolder. Where \`fab init\` (#21) generates the whole project, \`fab adapter scaffold <type>\` generates one stub on demand. Same template registry powers both — generated code stays consistent.

Closes #22. Unblocked by #18 (envelope) + #21 (init refactored to share registry).

## What's in

### Library: \`src/cli/init.ts\` (refactor + new exports)

- \`ADAPTER_TYPES\` (const) — all 8 supported types
- \`ADAPTER_INTERFACES\` (record) — type → \`AppAdapter\` / \`Reporter\` / \`ScenarioPlanner\`
- \`DEFAULT_ADAPTER_CLASS_NAMES\` (record) — type → \`My{Interface}\` default
- \`renderAdapterStub(type, {pkg?, className?})\` — single switch-based renderer
- \`scaffoldAdapter(type, {out?, name?, packageName?, force?})\` — writes one file or returns content
- \`ScaffoldAdapterError\` (codes: \`UNKNOWN_ADAPTER_TYPE\`, \`OUT_PATH_EXISTS\`)
- \`scaffoldProject()\` refactored to consume the same registry — eliminates 8 duplicated template functions

### CLI

\`fab adapter scaffold <type> [--out <path>] [--name <ClassName>] [--force] [--json]\`

- Without \`--out\`: pipes content to stdout (or to envelope's \`data.content\` in --json mode); progress line goes to stderr
- With \`--out\`: writes file, refuses overwrite without \`--force\`
- \`--name\` overrides the class name (e.g. \`AcmeAppAdapter\`)
- JSON envelope: \`{type, className, interfaceName, filePath, content?}\`

### Wired exports BEFORE opening PR (lesson from #20 + #21)

- \`src/index.ts\` — 7 runtime + 3 type exports
- \`src/index.test.ts\` — 10 new assertions
- Verified via \`node -e "require('./dist').scaffoldAdapter"\`

## Test plan

- [x] \`npm test\` — 426/426 pass (+29 new)
- [x] \`npm run build\` — clean
- [x] \`npm run check:boundary\` — pass (42 files)
- [x] All 8 adapter types covered (one CLI write test per type)
- [x] \`--name\` override, \`UNKNOWN_ADAPTER_TYPE\` envelope, \`OUT_PATH_EXISTS\` envelope, \`--force\`, pipe-mode envelope content

## Deferred to #26

- Real \`tsc --noEmit\` of generated stubs against installed package
- End-to-end: scaffold all 8 types into fresh project, wire into fabric.config.ts, compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)