### PR TITLE
feat: fab-mcp — MCP server wrapping all fab commands (#27)

### DIFF
--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -1,0 +1,153 @@
+# `fab-mcp` — install + usage
+
+`fab-mcp` is the Model Context Protocol server that wraps every `fab` command
+as a typed MCP tool. Install it once in your Claude Code MCP config and the
+agent can drive STF without bash + JSON parsing.
+
+---
+
+## Install
+
+After `npm install synthetic-test-fabric`, add `fab-mcp` to your Claude Code
+MCP config (`~/.claude/.mcp.json` or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "fab": {
+      "command": "fab-mcp"
+    }
+  }
+}
+```
+
+If `fab-mcp` isn't on `PATH`, point at the absolute path or use `npx`:
+
+```json
+{
+  "mcpServers": {
+    "fab": {
+      "command": "npx",
+      "args": ["fab-mcp"]
+    }
+  }
+}
+```
+
+Or for development against a checked-out copy:
+
+```json
+{
+  "mcpServers": {
+    "fab": {
+      "command": "node",
+      "args": ["/abs/path/to/synthetic-test-fabric/dist/mcp/server.js"]
+    }
+  }
+}
+```
+
+Verify by asking Claude `tools/list` for the `fab` server, or call
+`stf_status` directly.
+
+---
+
+## Tool surface (19 tools)
+
+All tools prefixed `stf_*`. Same data and same outcome semantics as the
+underlying `fab <command> --json` CLI.
+
+| Tool | Wraps | Tier |
+|------|-------|------|
+| `stf_status`            | `fab status`            | short (~1s) |
+| `stf_inspect`           | `fab inspect`           | short |
+| `stf_init`              | `fab init`              | short |
+| `stf_doctor`            | `fab doctor`            | medium (~2min) |
+| `stf_score`             | `fab score`             | short |
+| `stf_seed`              | `fab seed`              | short |
+| `stf_verify`            | `fab verify`            | short |
+| `stf_feedback`          | `fab feedback`          | short |
+| `stf_analyze`           | `fab analyze`           | short |
+| `stf_check`             | `fab check`             | short |
+| `stf_baseline_list`     | `fab baseline list`     | short |
+| `stf_baseline_update`   | `fab baseline update`   | short |
+| `stf_baseline_reset`    | `fab baseline reset`    | short |
+| `stf_adapter_scaffold`  | `fab adapter scaffold`  | short |
+| `stf_adapter_validate`  | `fab adapter validate`  | short |
+| `stf_smoke`             | `fab smoke`             | medium |
+| `stf_flows`             | `fab flows`             | long (~5min) |
+| `stf_fresh`             | `fab fresh`             | very long (~30min) |
+| `stf_orchestrate`       | `fab orchestrate`       | very long (~30min) |
+
+---
+
+## Outcome contract
+
+`fab-mcp` honors the #18 envelope taxonomy verbatim. Every tool response
+carries one JSON envelope in `content[0].text`:
+
+| `fab` envelope | MCP response | Read this from your agent |
+|----------------|--------------|---------------------------|
+| `status: "ok"`, `data.ok: true` (or just `data: {...}`) | success, content carries envelope | tool worked, use `data` |
+| `status: "ok"`, `data.ok: false` | success (NOT `isError`), content carries envelope | tool worked, your input failed a check (e.g. `stf_check` below threshold, `stf_adapter_validate` found missing methods) — fix and retry |
+| `status: "error"` | **MCP error** (`isError: true`), content carries full envelope | tool itself broke (file not found, parse error, etc.) — full envelope JSON in content so `error.code` (e.g. `AMBIGUOUS_ROOT`, `UNKNOWN_ROOT`, `INIT_CONFLICT`) survives the transport |
+
+**Always read both** the `isError` flag AND the envelope JSON in `content`.
+`isError: false` + `data.ok: false` is a normal domain failure.
+
+---
+
+## Timeout policy
+
+Each tool has a default timeout (see "Tier" column above). Long-running tools
+accept an optional `timeout_ms` input parameter to override per call:
+
+```jsonc
+// Override stf_orchestrate's default 30min timeout to 60min:
+{ "name": "stf_orchestrate", "arguments": { "iterations": 5, "timeout_ms": 3600000 } }
+```
+
+Global override via env: `FAB_MCP_TIMEOUT_MS=600000`.
+
+On timeout, `fab-mcp` SIGTERMs the child, escalates to SIGKILL after 5s, and
+returns an MCP error with `error.code: "TIMEOUT"` and the last ~50 lines of
+child stderr.
+
+---
+
+## Stderr forwarding
+
+Adapter / reporter / orchestrator progress lines (which `fab` routes to
+stderr in `--json` mode) are forwarded as MCP `notifications/message` log
+notifications. Your agent sees real-time progress AND a clean envelope at
+the end — neither contaminates the other.
+
+---
+
+## Path resolution
+
+`fab-mcp` resolves the bundled `fab` CLI relative to its own module location,
+not the consumer's cwd. Spawns via `process.execPath` (the running Node
+binary) to avoid PATH or version mismatches. Works when launched from any
+project directory.
+
+---
+
+## Active config
+
+`fab-mcp` propagates `FAB_CONFIG_PATH` and `FAB_STATE_DIR` to every child.
+Set them in your MCP config's `env`:
+
+```json
+{
+  "mcpServers": {
+    "fab": {
+      "command": "fab-mcp",
+      "env": {
+        "FAB_CONFIG_PATH": "/abs/path/to/fabric.config.ts",
+        "FAB_STATE_DIR": "/abs/path/to/.fab"
+      }
+    }
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.8.0",
         "commander": "^12.1.0",
         "pixelmatch": "^7.1.0",
@@ -1126,6 +1127,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1554,6 +1567,68 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2056,6 +2131,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2108,6 +2221,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2382,6 +2534,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -2494,11 +2670,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2506,6 +2690,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2687,12 +2887,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2720,7 +2977,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2735,7 +2991,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2815,6 +3070,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2874,7 +3138,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2884,6 +3147,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
@@ -2912,6 +3181,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -2935,7 +3213,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2945,7 +3222,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2955,7 +3231,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3031,6 +3306,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -3289,6 +3570,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3297,6 +3587,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -3358,11 +3669,96 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3408,6 +3804,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3459,6 +3871,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3535,6 +3968,24 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3567,7 +4018,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3597,7 +4047,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3632,7 +4081,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3763,7 +4211,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3822,7 +4269,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3851,7 +4297,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3860,12 +4305,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3885,6 +4359,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3998,6 +4488,24 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4084,6 +4592,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4101,7 +4615,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4784,6 +5297,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4838,6 +5360,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4997,10 +5525,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -5111,7 +5659,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {
@@ -5126,6 +5673,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -5235,6 +5791,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -5415,6 +6004,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5439,7 +6037,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5451,6 +6048,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5502,6 +6109,15 @@
       },
       "bin": {
         "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -5652,6 +6268,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -5689,6 +6318,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5709,6 +6353,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -5760,6 +6428,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5858,6 +6535,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5902,6 +6595,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5912,11 +6611,86 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5929,10 +6703,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6043,6 +6888,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -6225,6 +7079,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6392,6 +7255,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6425,6 +7327,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -6488,6 +7399,15 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6530,7 +7450,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6663,6 +7582,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "fab": "dist/cli/fab.js"
+    "fab": "dist/cli/fab.js",
+    "fab-mcp": "dist/mcp/server.js"
   },
   "scripts": {
     "prepare": "npm run build",
@@ -46,6 +47,7 @@
     "benchmark": "npx tsx demo/benchmark.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.8.0",
     "commander": "^12.1.0",
     "pixelmatch": "^7.1.0",
@@ -96,6 +98,7 @@
     "docs/persona-yaml-reference.md",
     "docs/lisa-mcp.md",
     "docs/cli-json-output.md",
+    "docs/mcp-install.md",
     "docs/claude-skills/README.md",
     "docs/claude-skills/skills/stf/",
     "docs/claude-skills/agents/stf-runner.md",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,4 +112,18 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp server (#27)', () => {
+    it.each([
+      'runFabCommand',
+      'FAB_CLI_PATH',
+      'RunFabResult',
+      'RunFabOptions',
+      'createMcpServer',
+      'TOOL_COUNT',
+      'TOOL_NAMES',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -117,6 +117,7 @@ describe('public API surface (src/index.ts)', () => {
     it.each([
       'runFabCommand',
       'FAB_CLI_PATH',
+      'resolveEnvTimeoutMs',
       'RunFabResult',
       'RunFabOptions',
       'createMcpServer',

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export type {
   ValidateAdapterOptions,
 } from './cli/adapter-validate';
 // MCP server — fab-mcp wrapping all fab commands as native MCP tools (added in #27).
-export { runFabCommand, FAB_CLI_PATH } from './mcp/runner';
+export { runFabCommand, FAB_CLI_PATH, resolveEnvTimeoutMs } from './mcp/runner';
 export type { RunFabResult, RunFabOptions } from './mcp/runner';
 export { createServer as createMcpServer, TOOL_COUNT, TOOL_NAMES } from './mcp/server';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,11 @@ export type {
   ValidationResult,
   ValidateAdapterOptions,
 } from './cli/adapter-validate';
+// MCP server — fab-mcp wrapping all fab commands as native MCP tools (added in #27).
+export { runFabCommand, FAB_CLI_PATH } from './mcp/runner';
+export type { RunFabResult, RunFabOptions } from './mcp/runner';
+export { createServer as createMcpServer, TOOL_COUNT, TOOL_NAMES } from './mcp/server';
+
 // Doctor — environment + peer-dep health check (added in #24).
 export { runDoctor } from './cli/doctor';
 export type {

--- a/src/mcp/runner.ts
+++ b/src/mcp/runner.ts
@@ -18,6 +18,21 @@ import * as path from 'path';
 /** Path to the bundled `fab` CLI, resolved relative to this compiled module. */
 export const FAB_CLI_PATH = path.resolve(__dirname, '..', 'cli', 'fab.js');
 
+/**
+ * Read FAB_MCP_TIMEOUT_MS env var as a positive integer, returning undefined
+ * when unset, empty, or unparseable (so the caller's fallback chain works).
+ *
+ * Exported so the MCP server can apply the env override at the server layer
+ * before passing an explicit timeoutMs into runFabCommand.
+ */
+export function resolveEnvTimeoutMs(): number | undefined {
+  const raw = process.env.FAB_MCP_TIMEOUT_MS;
+  if (!raw) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return n;
+}
+
 export interface RunFabResult {
   /** Parsed envelope from child stdout (single JSON object per #18 contract). */
   envelope: Record<string, unknown>;
@@ -51,7 +66,10 @@ export async function runFabCommand(
   args: string[],
   opts: RunFabOptions = {},
 ): Promise<RunFabResult> {
-  const timeoutMs = opts.timeoutMs ?? Number(process.env.FAB_MCP_TIMEOUT_MS) ?? 30_000;
+  // Resolve timeout precedence: per-call > FAB_MCP_TIMEOUT_MS env > 30s default.
+  // Important: ?? only catches null/undefined, not NaN — so guard against
+  // `Number(undefined) === NaN` and unparseable env values explicitly.
+  const timeoutMs = opts.timeoutMs ?? resolveEnvTimeoutMs() ?? 30_000;
   const argv = [...args, '--json'];
 
   return new Promise<RunFabResult>((resolve, reject) => {

--- a/src/mcp/runner.ts
+++ b/src/mcp/runner.ts
@@ -1,0 +1,168 @@
+/**
+ * Subprocess wrapper for the MCP server. Spawns the bundled `fab` CLI with
+ * `--json` and captures the envelope from stdout.
+ *
+ * Path resolution is relative to THIS module (not cwd), so `fab-mcp` works
+ * when launched from any consumer directory — not just the package root.
+ *
+ * Stdout-purity is preserved end-to-end:
+ *  - `--json` mode guarantees one JSON envelope on child stdout (per #18)
+ *  - We read child stdout to parse the envelope
+ *  - Child stderr is forwarded as MCP `notifications/message` log lines so
+ *    the agent sees adapter progress without it polluting the result
+ */
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+/** Path to the bundled `fab` CLI, resolved relative to this compiled module. */
+export const FAB_CLI_PATH = path.resolve(__dirname, '..', 'cli', 'fab.js');
+
+export interface RunFabResult {
+  /** Parsed envelope from child stdout (single JSON object per #18 contract). */
+  envelope: Record<string, unknown>;
+  /** Captured stderr (may be multi-line). Forwarded as MCP log notifications. */
+  stderr: string;
+  /** Process exit code; null if killed by signal. */
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  /** True if the wall-clock timeout fired. */
+  timedOut: boolean;
+}
+
+export interface RunFabOptions {
+  /** Working directory for the child. Defaults to process.cwd() at server start. */
+  cwd?: string;
+  /** Per-call timeout in ms. Falls back to FAB_MCP_TIMEOUT_MS env, then defaults. */
+  timeoutMs?: number;
+  /** Optional callback for stderr lines as they arrive (for MCP log forwarding). */
+  onStderrLine?: (line: string) => void;
+  /** Extra env passthrough. FAB_CONFIG_PATH and FAB_STATE_DIR auto-propagate. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Spawn the bundled `fab` CLI with the given args + `--json`, return the
+ * parsed envelope. Throws on subprocess crash, non-JSON stdout, or timeout —
+ * caller (mcp/server.ts) maps those to MCP error responses with the right
+ * synthesized envelope.
+ */
+export async function runFabCommand(
+  args: string[],
+  opts: RunFabOptions = {},
+): Promise<RunFabResult> {
+  const timeoutMs = opts.timeoutMs ?? Number(process.env.FAB_MCP_TIMEOUT_MS) ?? 30_000;
+  const argv = [...args, '--json'];
+
+  return new Promise<RunFabResult>((resolve, reject) => {
+    // Always spawn via process.execPath (the running Node binary) so we don't
+    // assume `node` is on PATH or the right version.
+    const child = spawn(process.execPath, [FAB_CLI_PATH, ...argv], {
+      cwd: opts.cwd ?? process.cwd(),
+      env: { ...process.env, ...opts.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let stderrBuffer = '';
+    let timedOut = false;
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stderr += text;
+      // Stream stderr line-by-line to the MCP log forwarder.
+      stderrBuffer += text;
+      const lines = stderrBuffer.split('\n');
+      stderrBuffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.length > 0 && opts.onStderrLine) opts.onStderrLine(line);
+      }
+    });
+
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      // Escalate to SIGKILL after 5s if the child hasn't exited.
+      setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5_000);
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(killTimer);
+      reject(err);
+    });
+
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(killTimer);
+
+      // Flush any unterminated final stderr line.
+      if (stderrBuffer.length > 0 && opts.onStderrLine) {
+        opts.onStderrLine(stderrBuffer);
+      }
+
+      if (timedOut) {
+        resolve({
+          envelope: synthesizedTimeoutEnvelope(args, timeoutMs, stderr),
+          stderr,
+          exitCode,
+          signal,
+          timedOut: true,
+        });
+        return;
+      }
+
+      // Try to parse stdout as the single envelope per #18 contract.
+      let envelope: Record<string, unknown>;
+      try {
+        const trimmed = stdout.trim();
+        if (!trimmed) {
+          envelope = synthesizedSubprocessEnvelope(args, exitCode, 'subprocess produced no stdout', stderr);
+        } else {
+          envelope = JSON.parse(trimmed) as Record<string, unknown>;
+        }
+      } catch (err) {
+        envelope = synthesizedSubprocessEnvelope(
+          args,
+          exitCode,
+          `subprocess stdout was not parseable JSON: ${(err as Error).message}`,
+          stderr,
+        );
+      }
+
+      resolve({ envelope, stderr, exitCode, signal, timedOut: false });
+    });
+
+    child.stdin.end();
+  });
+}
+
+function synthesizedTimeoutEnvelope(args: string[], timeoutMs: number, stderr: string): Record<string, unknown> {
+  return {
+    command: args[0] ?? 'fab',
+    status: 'error',
+    error: {
+      message: `fab subprocess exceeded ${timeoutMs}ms timeout and was killed`,
+      code: 'TIMEOUT',
+      stderr_tail: stderr.split('\n').slice(-50).join('\n'),
+    },
+  };
+}
+
+function synthesizedSubprocessEnvelope(
+  args: string[],
+  exitCode: number | null,
+  message: string,
+  stderr: string,
+): Record<string, unknown> {
+  return {
+    command: args[0] ?? 'fab',
+    status: 'error',
+    error: {
+      message,
+      code: 'SUBPROCESS_FAILED',
+      exit_code: exitCode,
+      stderr_tail: stderr.split('\n').slice(-50).join('\n'),
+    },
+  };
+}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -289,8 +289,9 @@ describe('fab-mcp — timeout precedence (review-flagged regressions)', () => {
   // tool calls — the server passed tool.defaultTimeoutMs straight through,
   // so the env never reached the runner.
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { runFabCommand, resolveEnvTimeoutMs } = require(path.join(REPO_ROOT, 'dist', 'mcp', 'runner.js'));
+  /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+  const { runFabCommand, resolveEnvTimeoutMs } = require(path.join(REPO_ROOT, 'dist', 'mcp', 'runner.js')) as typeof import('./runner');
+  /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 
   function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
     const original = process.env[key];

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,281 @@
+// Tests for fab-mcp — the MCP server wrapping fab commands.
+//
+// We spawn the BUILT server (dist/mcp/server.js) as a subprocess and speak
+// MCP over stdio. This mirrors how Claude Code talks to it. The dist must
+// be built before this test runs — if it's missing we build on demand so
+// the test isn't order-dependent.
+
+import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SERVER = path.join(REPO_ROOT, 'dist', 'mcp', 'server.js');
+
+beforeAll(() => {
+  if (!fs.existsSync(SERVER)) {
+    execSync('npm run build', { cwd: REPO_ROOT, stdio: 'inherit' });
+  }
+});
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number | string;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Spawn fab-mcp, send one or more JSON-RPC requests, return responses ordered
+ * by request id. Notifications (no `id`) are ignored — only count responses
+ * whose id matches one of the request ids we sent.
+ */
+async function rpcRoundTrip(
+  requests: Array<{ id?: number | string }>,
+  opts: { cwd?: string; env?: Record<string, string> } = {},
+): Promise<JsonRpcResponse[]> {
+  const child: ChildProcess = spawn(process.execPath, [SERVER], {
+    cwd: opts.cwd ?? REPO_ROOT,
+    env: { ...process.env, ...opts.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const expectedIds = new Set(requests.map((r) => r.id).filter((id) => id !== undefined));
+  let buffer = '';
+  const responses = new Map<number | string, JsonRpcResponse>();
+
+  child.stderr!.on('data', () => { /* swallow */ });
+
+  // Send all requests.
+  const payload = requests.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  child.stdin!.write(payload);
+
+  return new Promise<JsonRpcResponse[]>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(
+        `rpcRoundTrip timed out. Expected ${expectedIds.size} responses, got ${responses.size}. ` +
+        `Buffer tail: ${buffer.slice(-300)}`,
+      ));
+    }, 30_000);
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as JsonRpcResponse & { id?: number | string };
+          // Only count if it's a response to one of our requests.
+          if (parsed.id !== undefined && expectedIds.has(parsed.id)) {
+            responses.set(parsed.id, parsed);
+            if (responses.size === expectedIds.size) {
+              clearTimeout(timeout);
+              child.kill();
+              const ordered = requests
+                .filter((r): r is { id: number | string } => r.id !== undefined)
+                .map((r) => responses.get(r.id)!);
+              resolve(ordered);
+              return;
+            }
+          }
+        } catch {
+          /* not JSON — ignore */
+        }
+      }
+    });
+  });
+}
+
+interface McpToolResponse {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+function envelopeOf(response: McpToolResponse): Record<string, unknown> {
+  return JSON.parse(response.content[0].text) as Record<string, unknown>;
+}
+
+const initRequest = (id = 1): object => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'fab-mcp-test', version: '0.0.0' },
+  },
+});
+
+const listToolsRequest = (id = 2): object => ({
+  jsonrpc: '2.0', id, method: 'tools/list', params: {},
+});
+
+const callToolRequest = (id: number, name: string, args: Record<string, unknown> = {}): object => ({
+  jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args },
+});
+
+describe('fab-mcp — tools/list', () => {
+  it('returns exactly 19 tools, all prefixed stf_', async () => {
+    const [, listResp] = await rpcRoundTrip([initRequest(), listToolsRequest()]);
+    const tools = (listResp.result as { tools: Array<{ name: string }> }).tools;
+    expect(tools).toHaveLength(19);
+    for (const t of tools) {
+      expect(t.name).toMatch(/^stf_/);
+    }
+  });
+
+  it('every tool has an inputSchema', async () => {
+    const [, listResp] = await rpcRoundTrip([initRequest(), listToolsRequest()]);
+    const tools = (listResp.result as { tools: Array<{ name: string; inputSchema: unknown }> }).tools;
+    for (const t of tools) {
+      expect(t.inputSchema).toBeDefined();
+    }
+  });
+});
+
+describe('fab-mcp — tools/call envelope translation', () => {
+  it('stf_status (success) returns MCP success with envelope JSON', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_status', {})],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      expect(tool.isError).not.toBe(true);
+      const env = envelopeOf(tool);
+      expect(env.command).toBe('status');
+      expect(env.status).toBe('ok');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stf_check below threshold (domain failure) returns MCP success NOT isError', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-check-'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      // Pre-write a low-score fabric-score.json so check fails domain.
+      const iter = path.join(dir, 'iter-001');
+      fs.mkdirSync(iter, { recursive: true });
+      fs.writeFileSync(path.join(iter, 'fabric-score.json'), JSON.stringify({
+        simulationId: 'x', generatedAt: '2026-01-01T00:00:00Z', overall: 0.3, dimensions: {}, details: {},
+      }));
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_check', { root: dir, threshold: 0.5 })],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      // Domain failure: tool ran successfully, found a problem. NOT isError.
+      expect(tool.isError).not.toBe(true);
+      const env = envelopeOf(tool);
+      expect(env.status).toBe('ok');
+      expect((env.data as { ok: boolean }).ok).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stf_inspect on bad path (infra error) returns isError with full envelope', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_inspect', { root: '/tmp/definitely-not-' + Date.now() })],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      expect(tool.isError).toBe(true);
+      const env = envelopeOf(tool);
+      expect(env.status).toBe('error');
+      // Full envelope JSON survives the transport — error.code etc. preserved.
+      expect((env.error as { message: string }).message).toBeDefined();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stf_inspect on ambiguous root preserves AMBIGUOUS_ROOT code', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-ambig-'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      // Ambiguous: has both iter-001/ AND fabric-score.json at root.
+      fs.mkdirSync(path.join(dir, 'iter-001'));
+      fs.writeFileSync(path.join(dir, 'fabric-score.json'), '{}');
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_inspect', { root: dir })],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      expect(tool.isError).toBe(true);
+      const env = envelopeOf(tool);
+      expect((env.error as { code: string }).code).toBe('AMBIGUOUS_ROOT');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('unknown tool name returns isError with UNKNOWN_TOOL', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_nonexistent', {})],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      expect(tool.isError).toBe(true);
+      const env = envelopeOf(tool);
+      expect((env.error as { code: string }).code).toBe('UNKNOWN_TOOL');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invalid input shape returns isError with INVALID_INPUT', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      // stf_inspect requires `root` (string) — pass something invalid.
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_inspect', { root: 123 as unknown as string })],
+        { env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      expect(tool.isError).toBe(true);
+      const env = envelopeOf(tool);
+      expect((env.error as { code: string }).code).toBe('INVALID_INPUT');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('fab-mcp — runner path resolution', () => {
+  it('runFabCommand resolves the bundled fab CLI relative to its module', async () => {
+    // This is the regression test for the #27 path-resolution bug. Spawn
+    // fab-mcp from a cwd that does NOT contain the package — the server
+    // should still find dist/cli/fab.js relative to its own module.
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-cwd-'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+    try {
+      const [, , callResp] = await rpcRoundTrip(
+        [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_status', {})],
+        { cwd, env: { FAB_STATE_DIR: stateDir } },
+      );
+      const tool = callResp.result as McpToolResponse;
+      // Even from /tmp/random-dir, the server resolves the bundled fab
+      // CLI and stf_status returns successfully (empty state, but ok).
+      expect(tool.isError).not.toBe(true);
+      const env = envelopeOf(tool);
+      expect(env.status).toBe('ok');
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -279,3 +279,101 @@ describe('fab-mcp — runner path resolution', () => {
     }
   });
 });
+
+describe('fab-mcp — timeout precedence (review-flagged regressions)', () => {
+  // Reviewer finding: runFabCommand defaulted timeout to NaN because
+  // `Number(undefined)` is NaN and `?? 30_000` only catches null/undefined.
+  // Direct calls timed out immediately (setTimeout(NaN) fires synchronously).
+  //
+  // Reviewer finding: FAB_MCP_TIMEOUT_MS was documented but bypassed by MCP
+  // tool calls — the server passed tool.defaultTimeoutMs straight through,
+  // so the env never reached the runner.
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { runFabCommand, resolveEnvTimeoutMs } = require(path.join(REPO_ROOT, 'dist', 'mcp', 'runner.js'));
+
+  function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+    const original = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    try { return fn(); } finally {
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+  }
+
+  describe('resolveEnvTimeoutMs', () => {
+    it('returns undefined when env var is unset', () => {
+      withEnv('FAB_MCP_TIMEOUT_MS', undefined, () => {
+        expect(resolveEnvTimeoutMs()).toBeUndefined();
+      });
+    });
+
+    it('returns undefined when env var is empty', () => {
+      withEnv('FAB_MCP_TIMEOUT_MS', '', () => {
+        expect(resolveEnvTimeoutMs()).toBeUndefined();
+      });
+    });
+
+    it('returns undefined for unparseable values (no NaN leak)', () => {
+      withEnv('FAB_MCP_TIMEOUT_MS', 'not-a-number', () => {
+        expect(resolveEnvTimeoutMs()).toBeUndefined();
+      });
+    });
+
+    it('returns undefined for non-positive values', () => {
+      withEnv('FAB_MCP_TIMEOUT_MS', '0', () => {
+        expect(resolveEnvTimeoutMs()).toBeUndefined();
+      });
+      withEnv('FAB_MCP_TIMEOUT_MS', '-100', () => {
+        expect(resolveEnvTimeoutMs()).toBeUndefined();
+      });
+    });
+
+    it('returns the parsed integer for positive numeric values', () => {
+      withEnv('FAB_MCP_TIMEOUT_MS', '5000', () => {
+        expect(resolveEnvTimeoutMs()).toBe(5000);
+      });
+    });
+  });
+
+  describe('runFabCommand default timeout', () => {
+    it('does NOT time out immediately when neither opts.timeoutMs nor env is set', async () => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+      try {
+        const r = await withEnv('FAB_MCP_TIMEOUT_MS', undefined, () => runFabCommand(
+          ['status'],
+          { env: { FAB_STATE_DIR: stateDir } },
+        ));
+        expect(r.timedOut).toBe(false);
+        expect(r.envelope.command).toBe('status');
+        expect(r.envelope.status).toBe('ok');
+      } finally {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('FAB_MCP_TIMEOUT_MS env path through MCP tool calls', () => {
+    it('a generously high env timeout completes a normal call cleanly', async () => {
+      // The reverse case (low env timeout firing) needs a slow command which
+      // we can't safely synthesize without a fixture. The high-timeout case
+      // proves the env value is being honored (no NaN, no immediate timeout)
+      // — combined with resolveEnvTimeoutMs unit tests above this is enough
+      // to lock the precedence in.
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fab-mcp-test-state-'));
+      try {
+        const responses = await rpcRoundTrip(
+          [initRequest(), listToolsRequest(), callToolRequest(3, 'stf_status', {})],
+          { env: { FAB_STATE_DIR: stateDir, FAB_MCP_TIMEOUT_MS: '60000' } },
+        );
+        const tool = responses[2].result as McpToolResponse;
+        expect(tool.isError).not.toBe(true);
+        const env = envelopeOf(tool);
+        expect(env.status).toBe('ok');
+      } finally {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,7 +24,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
-import { runFabCommand } from './runner';
+import { runFabCommand, resolveEnvTimeoutMs } from './runner';
 
 // ---------------------------------------------------------------------------
 // Tool registry
@@ -392,7 +392,11 @@ export function createServer(): Server {
 
     const inputObj = input as { timeout_ms?: number };
     const fabArgs = tool.buildArgs(input);
-    const timeoutMs = inputObj.timeout_ms ?? tool.defaultTimeoutMs;
+    // Precedence: per-call input.timeout_ms > FAB_MCP_TIMEOUT_MS env > tool default.
+    // Env was advertised in docs/mcp-install.md but bypassed before — the
+    // server passed tool.defaultTimeoutMs straight through, so the env never
+    // reached the runner.
+    const timeoutMs = inputObj.timeout_ms ?? resolveEnvTimeoutMs() ?? tool.defaultTimeoutMs;
 
     // Run, forwarding stderr lines as MCP log notifications so the agent
     // can see adapter progress without it polluting the result envelope.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,486 @@
+#!/usr/bin/env node
+/**
+ * `fab-mcp` — MCP server wrapping every `fab` command.
+ *
+ * Exposes 19 tools, all prefixed `stf_*`, that subprocess into the bundled
+ * `fab` CLI with `--json`. Outcome translation honors the #18 caller contract:
+ *
+ *   status: "ok"  + data.ok: true       → MCP success (envelope JSON in content)
+ *   status: "ok"  + data.ok: false       → MCP success (NOT isError; agent reads data.ok)
+ *   status: "error"                       → MCP error (isError: true; full envelope in content)
+ *
+ * Stdout-purity is preserved end-to-end via mcp/runner.ts: child stdout is
+ * the only source for the envelope; child stderr is forwarded as MCP log
+ * notifications so adapter progress reaches the agent without contaminating
+ * the result.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  LoggingMessageNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { runFabCommand } from './runner';
+
+// ---------------------------------------------------------------------------
+// Tool registry
+// ---------------------------------------------------------------------------
+
+/** Per-tool default timeout in ms. */
+const TIMEOUT_SHORT  = 30_000;
+const TIMEOUT_MEDIUM = 120_000;
+const TIMEOUT_LONG   = 300_000;
+const TIMEOUT_XLONG  = 1_800_000;
+
+interface ToolDefinition {
+  name: string;
+  description: string;
+  /** zod schema for input validation. */
+  schema: z.ZodTypeAny;
+  /** Default timeout if input doesn't override via timeout_ms. */
+  defaultTimeoutMs: number;
+  /** Build the fab CLI argv from the validated input. */
+  buildArgs: (input: any) => string[];
+}
+
+// Common option shapes.
+const rootSchema = { root: z.string().describe('Loop root or iteration root directory') };
+const optionalTimeout = { timeout_ms: z.number().int().positive().optional().describe('Per-call timeout in milliseconds (overrides default)') };
+
+const TOOLS: ToolDefinition[] = [
+  // ── short / interactive ─────────────────────────────────────────────
+  {
+    name: 'stf_status',
+    description: '"Where am I" — show the most recent fab command outcome from ~/.fab/state.json. First call when orienting.',
+    schema: z.object({}),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: () => ['status'],
+  },
+  {
+    name: 'stf_inspect',
+    description: 'Structured summary of a loop or iteration root. Returns phase, score, flows, recent behavior events, latest screenshot.',
+    schema: z.object({
+      ...rootSchema,
+      kind: z.enum(['loop', 'iteration']).optional().describe('Force interpretation when path is ambiguous'),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['inspect', '--root', input.root];
+      if (input.kind) args.push('--kind', input.kind);
+      return args;
+    },
+  },
+  {
+    name: 'stf_init',
+    description: 'Scaffold a new fabric.config.ts + 8 adapter stubs into a target directory. Use when onboarding a new product to STF.',
+    schema: z.object({
+      dir: z.string().optional().describe('Target directory (default: cwd)'),
+      force: z.boolean().optional().describe('Overwrite existing files'),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['init'];
+      if (input.dir) args.push('--dir', input.dir);
+      if (input.force) args.push('--force');
+      return args;
+    },
+  },
+  {
+    name: 'stf_doctor',
+    description: 'Pre-flight environment + peer-dep health check. Run before onboarding or when CI is failing for opaque reasons.',
+    schema: z.object({
+      deep: z.boolean().optional().describe('Include heavy checks (playwright browsers, demo run)'),
+      ...optionalTimeout,
+    }),
+    defaultTimeoutMs: TIMEOUT_MEDIUM,
+    buildArgs: (input) => {
+      const args = ['doctor'];
+      if (input.deep) args.push('--deep');
+      return args;
+    },
+  },
+  {
+    name: 'stf_score',
+    description: 'Compute fabric score from an existing run root. Reads fabric-score.json via the scoring adapter.',
+    schema: z.object(rootSchema),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => ['score', '--root', input.root],
+  },
+  {
+    name: 'stf_seed',
+    description: 'Seed simulation fixtures into a run root. Primitive — usually called via fab smoke / fresh / orchestrate.',
+    schema: z.object({
+      ...rootSchema,
+      scenario: z.string().optional(),
+      seekers: z.number().int().nonnegative().optional(),
+      employers: z.number().int().nonnegative().optional(),
+      employees: z.number().int().nonnegative().optional(),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['seed', '--root', input.root];
+      if (input.scenario) args.push('--scenario', input.scenario);
+      if (input.seekers != null)   args.push('--seekers', String(input.seekers));
+      if (input.employers != null) args.push('--employers', String(input.employers));
+      if (input.employees != null) args.push('--employees', String(input.employees));
+      return args;
+    },
+  },
+  {
+    name: 'stf_verify',
+    description: 'Fail-closed fixture verification on an existing run root.',
+    schema: z.object(rootSchema),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => ['verify', '--root', input.root],
+  },
+  {
+    name: 'stf_feedback',
+    description: 'Generate feedback JSON from an existing run root. Requires fabric-score.json present (run stf_score first).',
+    schema: z.object(rootSchema),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => ['feedback', '--root', input.root],
+  },
+  {
+    name: 'stf_analyze',
+    description: 'Extract discovered screen paths from behavior events.',
+    schema: z.object(rootSchema),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => ['analyze', '--root', input.root],
+  },
+  {
+    name: 'stf_check',
+    description: 'CI score gate — exit 1 if fabric-score.json overall is below threshold. Returns data.ok=false on threshold failure (NOT isError).',
+    schema: z.object({
+      ...rootSchema,
+      threshold: z.number().optional().describe('Minimum passing score (0-10), default 8.0'),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['check', '--root', input.root];
+      if (input.threshold != null) args.push('--threshold', String(input.threshold));
+      return args;
+    },
+  },
+  // ── baseline trio ───────────────────────────────────────────────────
+  {
+    name: 'stf_baseline_list',
+    description: 'List all visual regression baselines.',
+    schema: z.object({ baseline_dir: z.string().optional() }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['baseline', 'list'];
+      if (input.baseline_dir) args.push('--baseline-dir', input.baseline_dir);
+      return args;
+    },
+  },
+  {
+    name: 'stf_baseline_update',
+    description: 'Accept the current screenshot as the new baseline for a flow.',
+    schema: z.object({
+      flow: z.string(),
+      ...rootSchema,
+      baseline_dir: z.string().optional(),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['baseline', 'update', input.flow, '--root', input.root];
+      if (input.baseline_dir) args.push('--baseline-dir', input.baseline_dir);
+      return args;
+    },
+  },
+  {
+    name: 'stf_baseline_reset',
+    description: 'Delete all baselines — next run will re-capture from scratch.',
+    schema: z.object({ baseline_dir: z.string().optional() }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['baseline', 'reset'];
+      if (input.baseline_dir) args.push('--baseline-dir', input.baseline_dir);
+      return args;
+    },
+  },
+  // ── adapter scaffolding + validation ────────────────────────────────
+  {
+    name: 'stf_adapter_scaffold',
+    description: 'Generate a single adapter stub. type ∈ {app, simulation, scoring, feedback, memory, browser, reporter, planner}.',
+    schema: z.object({
+      type: z.enum(['app', 'simulation', 'scoring', 'feedback', 'memory', 'browser', 'reporter', 'planner']),
+      out: z.string().optional().describe('Output file path (omit to receive content in envelope.data.content)'),
+      name: z.string().optional().describe('Override the generated class name'),
+      force: z.boolean().optional(),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['adapter', 'scaffold', input.type];
+      if (input.out)   args.push('--out', input.out);
+      if (input.name)  args.push('--name', input.name);
+      if (input.force) args.push('--force');
+      return args;
+    },
+  },
+  {
+    name: 'stf_adapter_validate',
+    description: 'Type-check a TS adapter file against its target interface. Reports missing methods. Returns data.ok=false on validation failure (NOT isError).',
+    schema: z.object({
+      path: z.string(),
+      type: z.enum(['app', 'simulation', 'scoring', 'feedback', 'memory', 'browser', 'reporter', 'planner']).optional()
+        .describe('Force adapter type (default: auto-detect from class name suffix)'),
+    }),
+    defaultTimeoutMs: TIMEOUT_SHORT,
+    buildArgs: (input) => {
+      const args = ['adapter', 'validate', input.path];
+      if (input.type) args.push('--type', input.type);
+      return args;
+    },
+  },
+  // ── medium / smoke ──────────────────────────────────────────────────
+  {
+    name: 'stf_smoke',
+    description: 'Fastest handoff check: seed → verify → one bounded smoke flow. Use for "is everything wired correctly".',
+    schema: z.object({
+      root: z.string().optional(),
+      keep: z.boolean().optional().describe('Keep the run root after completion'),
+      ...optionalTimeout,
+    }),
+    defaultTimeoutMs: TIMEOUT_MEDIUM,
+    buildArgs: (input) => {
+      const args = ['smoke'];
+      if (input.root) args.push('--root', input.root);
+      if (input.keep) args.push('--keep');
+      return args;
+    },
+  },
+  // ── long / flows ────────────────────────────────────────────────────
+  {
+    name: 'stf_flows',
+    description: 'Run Playwright flows against an existing run root.',
+    schema: z.object({
+      ...rootSchema,
+      grep: z.string().optional(),
+      project: z.string().optional().describe('Playwright project name (default: flows)'),
+      ...optionalTimeout,
+    }),
+    defaultTimeoutMs: TIMEOUT_LONG,
+    buildArgs: (input) => {
+      const args = ['flows', '--root', input.root];
+      if (input.grep)    args.push('--grep', input.grep);
+      if (input.project) args.push('--project', input.project);
+      return args;
+    },
+  },
+  // ── very long / orchestrate + fresh ─────────────────────────────────
+  {
+    name: 'stf_fresh',
+    description: 'One-shot fresh run: seed → verify → optionally flows → optionally score+feedback. Heavy; default 30min timeout.',
+    schema: z.object({
+      flows: z.boolean().optional(),
+      plan: z.boolean().optional().describe('Compute score and generate feedback after seeding'),
+      scenario: z.string().optional(),
+      root: z.string().optional(),
+      keep: z.boolean().optional(),
+      seekers: z.number().int().nonnegative().optional(),
+      employers: z.number().int().nonnegative().optional(),
+      employees: z.number().int().nonnegative().optional(),
+      ...optionalTimeout,
+    }),
+    defaultTimeoutMs: TIMEOUT_XLONG,
+    buildArgs: (input) => {
+      const args = ['fresh'];
+      if (input.flows)    args.push('--flows');
+      if (input.plan)     args.push('--plan');
+      if (input.scenario) args.push('--scenario', input.scenario);
+      if (input.root)     args.push('--root', input.root);
+      if (input.keep)     args.push('--keep');
+      if (input.seekers != null)   args.push('--seekers', String(input.seekers));
+      if (input.employers != null) args.push('--employers', String(input.employers));
+      if (input.employees != null) args.push('--employees', String(input.employees));
+      return args;
+    },
+  },
+  {
+    name: 'stf_orchestrate',
+    description: 'Full autonomous loop: SEED → VERIFY → RUN → ANALYZE → GENERATE_FLOWS → TEST → SCORE → FEEDBACK. Heavy; default 30min timeout.',
+    schema: z.object({
+      iterations: z.number().int().positive().optional(),
+      ticks: z.number().int().positive().optional(),
+      seekers: z.number().int().nonnegative().optional(),
+      employers: z.number().int().nonnegative().optional(),
+      employees: z.number().int().nonnegative().optional(),
+      scenario: z.string().optional(),
+      root: z.string().optional(),
+      live_llm: z.boolean().optional(),
+      allow_regression_failures: z.boolean().optional(),
+      ...optionalTimeout,
+    }),
+    defaultTimeoutMs: TIMEOUT_XLONG,
+    buildArgs: (input) => {
+      const args = ['orchestrate'];
+      if (input.iterations != null) args.push('--iterations', String(input.iterations));
+      if (input.ticks != null)      args.push('--ticks', String(input.ticks));
+      if (input.seekers != null)    args.push('--seekers', String(input.seekers));
+      if (input.employers != null)  args.push('--employers', String(input.employers));
+      if (input.employees != null)  args.push('--employees', String(input.employees));
+      if (input.scenario)           args.push('--scenario', input.scenario);
+      if (input.root)               args.push('--root', input.root);
+      if (input.live_llm)           args.push('--live-llm');
+      if (input.allow_regression_failures) args.push('--allow-regression-failures');
+      return args;
+    },
+  },
+];
+
+/** Exact tool count for #26's tools/list assertion. */
+export const TOOL_COUNT = TOOLS.length;
+export const TOOL_NAMES = TOOLS.map((t) => t.name) as readonly string[];
+
+// ---------------------------------------------------------------------------
+// Server setup
+// ---------------------------------------------------------------------------
+
+export function createServer(): Server {
+  const server = new Server(
+    { name: 'fab-mcp', version: '0.1.0' },
+    { capabilities: { tools: {}, logging: {} } },
+  );
+
+  // tools/list
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: TOOLS.map((t) => ({
+      name: t.name,
+      description: t.description,
+      // Convert zod schema to JSON Schema for the MCP wire format. We use a
+      // minimal converter: each tool's zod schema is a z.object — we translate
+      // the top-level shape directly.
+      inputSchema: zodObjectToJsonSchema(t.schema),
+    })),
+  }));
+
+  // tools/call
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+    const tool = TOOLS.find((t) => t.name === name);
+    if (!tool) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: JSON.stringify({
+          command: name,
+          status: 'error',
+          error: { message: `unknown tool: ${name}`, code: 'UNKNOWN_TOOL' },
+        }) }],
+      };
+    }
+
+    // Validate input against the tool's zod schema. zod errors are
+    // infrastructure errors (the agent sent garbage).
+    let input;
+    try {
+      input = tool.schema.parse(args ?? {});
+    } catch (err) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: JSON.stringify({
+          command: name,
+          status: 'error',
+          error: { message: `input validation failed: ${(err as Error).message}`, code: 'INVALID_INPUT' },
+        }) }],
+      };
+    }
+
+    const inputObj = input as { timeout_ms?: number };
+    const fabArgs = tool.buildArgs(input);
+    const timeoutMs = inputObj.timeout_ms ?? tool.defaultTimeoutMs;
+
+    // Run, forwarding stderr lines as MCP log notifications so the agent
+    // can see adapter progress without it polluting the result envelope.
+    const result = await runFabCommand(fabArgs, {
+      timeoutMs,
+      onStderrLine: (line) => {
+        server.notification({
+          method: 'notifications/message',
+          params: { level: 'info', logger: 'fab-mcp', data: line },
+        }).catch(() => {/* best-effort log forwarding */});
+      },
+    });
+
+    return mapEnvelopeToMcp(result.envelope);
+  });
+
+  return server;
+}
+
+/**
+ * Map a #18 envelope to an MCP tool response per the #27 caller contract:
+ *
+ *   status:"ok"  + data.ok:true   → MCP success (envelope JSON in content)
+ *   status:"ok"  + data.ok:false   → MCP success (NOT isError; agent reads data.ok)
+ *   status:"error"                  → MCP error (isError:true; full envelope JSON)
+ *
+ * Full envelope JSON in content (not just error.message) so codes like
+ * AMBIGUOUS_ROOT / UNKNOWN_ROOT / INIT_CONFLICT survive the transport.
+ */
+function mapEnvelopeToMcp(envelope: Record<string, unknown>): { isError?: boolean; content: Array<{ type: 'text'; text: string }> } {
+  const text = JSON.stringify(envelope);
+  const isInfraError = envelope.status === 'error';
+  return {
+    isError: isInfraError ? true : undefined,
+    content: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * Minimal zod → JSON Schema converter. Handles z.object with the field types
+ * we use (z.string, z.number, z.boolean, z.enum, z.optional). Good enough
+ * for tool input schemas; not a general-purpose converter.
+ */
+function zodObjectToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  if (!(schema instanceof z.ZodObject)) {
+    return { type: 'object' };
+  }
+  const shape = schema.shape;
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const [key, value] of Object.entries(shape)) {
+    const isOptional = (value as z.ZodTypeAny).isOptional();
+    const inner = isOptional ? (value as z.ZodOptional<z.ZodTypeAny>)._def.innerType : (value as z.ZodTypeAny);
+    properties[key] = zodTypeToJsonSchema(inner);
+    if (!isOptional) required.push(key);
+  }
+
+  return required.length > 0
+    ? { type: 'object', properties, required }
+    : { type: 'object', properties };
+}
+
+function zodTypeToJsonSchema(t: z.ZodTypeAny): Record<string, unknown> {
+  const description = t.description;
+  const base: Record<string, unknown> = description ? { description } : {};
+
+  if (t instanceof z.ZodString)  return { ...base, type: 'string' };
+  if (t instanceof z.ZodNumber)  return { ...base, type: 'number' };
+  if (t instanceof z.ZodBoolean) return { ...base, type: 'boolean' };
+  if (t instanceof z.ZodEnum)    return { ...base, type: 'string', enum: t._def.values };
+  if (t instanceof z.ZodObject)  return { ...base, ...zodObjectToJsonSchema(t) };
+  return { ...base, type: 'string' };  // fallback
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — only runs when invoked as `fab-mcp` (not when imported)
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  server.connect(transport).catch((err) => {
+    process.stderr.write(`[fab-mcp] fatal: ${(err as Error).message}\n`);
+    process.exit(1);
+  });
+}
+
+// LoggingMessageNotificationSchema referenced for type clarity even though
+// we use server.notification directly. Keeps the import obvious to readers.
+void LoggingMessageNotificationSchema;


### PR DESCRIPTION
## Summary

Native MCP server (`fab-mcp`) exposing every `fab` command as a typed `stf_*` tool. Subprocess wrapper around `fab <cmd> --json` — same source of truth as the CLI, no contract divergence.

Closes #27. Unblocked by #18–#24 (envelope + every command exists). Stacked on #25 (skill).

## What's in

### Library

- **`runFabCommand(args, opts)`** in `src/mcp/runner.ts`
  - Path resolved relative to module: `path.resolve(__dirname, '../cli/fab.js')` — works from any consumer cwd, not just package root
  - Spawns via `process.execPath` — no PATH or version assumption
  - Reads child stdout for envelope; child stderr forwarded line-by-line via `onStderrLine` callback
  - Per-call `timeoutMs` override; `FAB_MCP_TIMEOUT_MS` env override
  - SIGTERM → 5s wait → SIGKILL escalation
  - Synthesized error envelope on TIMEOUT / SUBPROCESS_FAILED (with last 50 lines of stderr)

- **`createMcpServer()`** in `src/mcp/server.ts`
  - 19 tools, all prefixed `stf_*` (matches `TOOL_COUNT`)
  - Per-tool zod input schemas → JSON Schema for MCP wire format
  - Per-tier defaults: short 30s / medium 2min / long 5min / very-long 30min
  - Outcome translation per #18 caller contract (full envelope JSON in content; `error.code` survives)
  - Stderr forwarded as MCP `notifications/message` (never mixed with result envelope)

### CLI

- `bin: { "fab-mcp": "dist/mcp/server.js" }` — installed to PATH on `npm install`

### Package changes

- `@modelcontextprotocol/sdk@^1` added as runtime dep (was transitive via lisa-mcp peer; now direct)
- `docs/mcp-install.md` added to files allowlist

### Wired exports BEFORE opening PR

`runFabCommand`, `FAB_CLI_PATH`, `RunFabResult`, `RunFabOptions`, `createMcpServer`, `TOOL_COUNT`, `TOOL_NAMES` — all in `src/index.ts` + 7 new assertions in `src/index.test.ts`.

## Test plan

- [x] `npm test` — 504/504 pass (+9 new MCP tests + 7 index.ts assertions)
- [x] `npm run build` — clean
- [x] `npm run check:boundary` — pass (46 files)
- [x] `npm run check:package-surface` — pass (133 packed files)
- [x] tools/list returns exactly 19 tools, all stf_-prefixed
- [x] Outcome taxonomy round-trips (success / domain failure / infra error / ambiguous root)
- [x] Path resolution from outside package root (regression test for the #27 bug class)
- [x] Unknown tool / invalid input shape → typed error codes

## Outcome translation table

| `fab` envelope | MCP response |
|----------------|--------------|
| `status:"ok"`, `data.ok:true` (or just `data:...`) | success, content carries envelope |
| `status:"ok"`, `data.ok:false` | success (NOT `isError`), content carries envelope — agent reads `data.ok` |
| `status:"error"` | MCP error (`isError:true`), full envelope JSON in content (preserves `error.code`) |
| Subprocess crash / timeout / non-JSON stdout | MCP error with synthesized envelope, codes `SUBPROCESS_FAILED` / `TIMEOUT` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)