### PR TITLE
test: v0.4.0 integration + release-readiness verification (#26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,13 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: |
+          mapfile -t tests < <(npx jest --listTests --runInBand)
+          for test_file in "${tests[@]}"; do
+            echo "::group::${test_file#$GITHUB_WORKSPACE/}"
+            timeout 120s npx jest --forceExit --runInBand --testTimeout=15000 --runTestsByPath "$test_file"
+            echo "::endgroup::"
+          done
 
   demo:
     name: Demo (full loop)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,9 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
-    # Floor on stuck-runner zombie state — local run is ~10s, CI typically ~60s.
-    # If a runner zombies out, fail fast instead of letting the job hang for
-    # GitHub's default 360-minute timeout.
-    timeout-minutes: 10
+    # Keep a real ceiling for stuck runners, but leave enough room for the
+    # CLI-heavy Jest suites, which spawn many tsx subprocesses on GitHub Linux.
+    timeout-minutes: 30
 
     # NOTE: matrix temporarily reduced to single Node version (was [20.x, 22.x])
     # to dodge a GitHub Actions runner-pool flakiness on this repo (Build & Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,96 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.4.0] — agent-friendly surface
+
+The CLI surface a Claude Code (or similar) agent can drive end-to-end.
+Ships both `fab` (CLI) and `fab-mcp` (native MCP server) so agents can
+use whichever transport is available — same envelope contract on either side.
+
+### Added — CLI
+
+- **`fab status`** (#19) — cross-run state from `~/.fab/state.json`
+- **`fab inspect`** (#20) — structured `RunRootSummary` with strict
+  `AmbiguousRootError` / `UnknownRootError` typed errors and SQLite
+  behavior-event reads
+- **`fab init`** (#21) — scaffold a parseable `fabric.config.ts` + 8 adapter stubs
+- **`fab adapter scaffold <type>`** (#22) — generate one stub on demand for
+  any of the 8 adapter types
+- **`fab adapter validate <path>`** (#23) — type-check an adapter file
+  against its target interface (method-presence detection via TS Compiler API)
+- **`fab doctor`** (#24) — pre-flight env + peer-dep health check, with
+  default vs `--deep` tiers and active-config-aware peer escalation
+
+### Added — `--json` envelope contract (#18)
+
+Every command accepts `--json` and emits exactly one envelope on stdout
+(documented in `docs/cli-json-output.md`):
+
+| Outcome | Envelope | Exit |
+|---------|----------|------|
+| Success | `{status: "ok", data: {ok: true, ...}}` | 0 |
+| Domain failure | `{status: "ok", data: {ok: false, ...}}` | 1 |
+| Infrastructure error | `{status: "error", error: {message, code?}}` | 1 |
+
+**Caller contract**: read both the exit code AND the envelope fields.
+`status` describes infrastructure outcome; `data.ok` describes domain
+outcome where applicable.
+
+### Added — MCP server (#27)
+
+- **`fab-mcp`** binary — Model Context Protocol server wrapping every `fab`
+  command as a typed `stf_*` tool (19 tools total)
+- Subprocess wrapper preserves the CLI envelope contract end-to-end
+- Per-tool zod schemas, per-tier timeouts (30s / 2min / 5min / 30min),
+  `FAB_MCP_TIMEOUT_MS` env override
+- Stderr forwarded as MCP `notifications/message` log lines so adapter
+  progress reaches the agent without contaminating the result envelope
+- Path resolution relative to module — works from any consumer cwd
+- See `docs/mcp-install.md` for installation snippets
+
+### Added — Library exports
+
+`scaffoldProject`, `scaffoldAdapter`, `validateAdapter`, `runDoctor`,
+`inspectRunRoot`, `runFabCommand`, `createMcpServer`, plus typed errors
+(`AmbiguousRootError`, `UnknownRootError`, `InitConflictError`,
+`AdapterValidateError`, `ScaffoldAdapterError`, `FabError`) and helper
+constants (`ADAPTER_TYPES`, `ADAPTER_INTERFACES`, `TOOL_NAMES`, etc.).
+
+### Added — Agent-side install (#25)
+
+- Decision tree in root `CLAUDE.md` (additive — preserves existing repo
+  guidance) mapping ~12 user intents to both `fab` commands and `stf_*`
+  MCP tools
+- New skill at `docs/claude-skills/skills/stf/SKILL.md`
+- New agent stub at `docs/claude-skills/agents/stf-runner.md` (Haiku, read-only)
+
+### Changed
+
+- `typescript` moved from `devDependencies` → `dependencies` (runtime use
+  by `fab adapter validate`)
+- `@modelcontextprotocol/sdk@^1` added as a direct runtime dep
+- `commander` `parseInt` callback bug fixed — every numeric flag had been
+  passing `NaN` to its action since the original CLI shipped (latent bug
+  surfaced by the orchestrate writeback test in #19)
+- `fab adapter validate` now records into state (was missing; surfaced by
+  #26 integration tests)
+- CI workflow: `concurrency: cancel-in-progress`, `timeout-minutes`,
+  `--runInBand --testTimeout=15000`, single-Node matrix temporarily
+  (TODO: restore [20.x, 22.x] when GH runner pool stabilizes)
+
+### Verified by #26 release-readiness suite
+
+- E2E CLI flow: `init → adapter scaffold → adapter validate → doctor → status`
+- E2E MCP flow: same chain via `fab-mcp` stdio
+- `npm pack` + install in temp consumer dir + `npx fab-mcp` round-trip
+  from outside package root (path-resolution canary)
+- Backward-compat text-mode framing snapshots from #18 still pass
+- Static taxonomy lint: no command emits `status: "error"` for an expected
+  domain failure
+- Decision-tree → real-tool docs accuracy
+
+---
+
 ## [0.3.0] — 2026-04-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "fab": "dist/cli/fab.js"
+        "fab": "dist/cli/fab.js",
+        "fab-mcp": "dist/mcp/server.js"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/src/cli/__test-helpers__/cli-runner.ts
+++ b/src/cli/__test-helpers__/cli-runner.ts
@@ -25,6 +25,7 @@ export interface RunFabResult {
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 const TSX_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
 const FAB_SRC = path.join(REPO_ROOT, 'src', 'cli', 'fab.ts');
+const FAB_DIST = path.join(REPO_ROOT, 'dist', 'cli', 'fab.js');
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
@@ -42,7 +43,11 @@ export async function runFab(args: string[], opts: RunFabOptions = {}): Promise<
     const isolatedStateDir = opts.env?.FAB_STATE_DIR
       ?? fs.mkdtempSync(path.join(os.tmpdir(), 'fab-test-state-'));
 
-    const child = spawn(TSX_BIN, [FAB_SRC, ...args], {
+    const hasBuiltCli = fs.existsSync(FAB_DIST);
+    const command = hasBuiltCli ? process.execPath : TSX_BIN;
+    const commandArgs = hasBuiltCli ? [FAB_DIST, ...args] : [FAB_SRC, ...args];
+
+    const child = spawn(command, commandArgs, {
       cwd: opts.cwd ?? process.cwd(),
       env: { ...process.env, FAB_STATE_DIR: isolatedStateDir, ...opts.env },
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/cli/__test-helpers__/cli-runner.ts
+++ b/src/cli/__test-helpers__/cli-runner.ts
@@ -56,6 +56,7 @@ export async function runFab(args: string[], opts: RunFabOptions = {}): Promise<
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    let closed = false;
 
     child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
     child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
@@ -64,7 +65,7 @@ export async function runFab(args: string[], opts: RunFabOptions = {}): Promise<
       timedOut = true;
       child.kill('SIGTERM');
       // Escalate to SIGKILL if still alive after 2s
-      setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2_000);
+      setTimeout(() => { if (!closed) child.kill('SIGKILL'); }, 2_000);
     }, timeoutMs);
 
     child.on('error', (err) => {
@@ -73,6 +74,7 @@ export async function runFab(args: string[], opts: RunFabOptions = {}): Promise<
     });
 
     child.on('close', (exitCode, signal) => {
+      closed = true;
       clearTimeout(timer);
       resolve({
         stdout,

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -13,6 +13,12 @@ function tmpDir(prefix: string): string {
 function tmpStateDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'fab-state-test-'));
 }
+function tmpFile(prefix: string): string {
+  const dir = tmpDir(prefix);
+  const file = path.join(dir, 'not-a-directory');
+  fs.writeFileSync(file, 'x');
+  return file;
+}
 
 function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
   const original: Record<string, string | undefined> = {};
@@ -57,11 +63,15 @@ describe('runDoctor — library', () => {
   });
 
   it('fails when state dir is unwritable', () => {
-    // Override FAB_STATE_DIR to a definitely-unwritable path.
-    const result = withEnv({ FAB_STATE_DIR: '/proc/1/cant-write' }, () => runDoctor({ cwd: process.cwd() }));
-    const stateCheck = result.checks.find((c) => c.name === 'state-dir');
-    expect(stateCheck?.status).toBe('fail');
-    expect(result.ok).toBe(false);
+    const stateDir = tmpFile('state-dir-file');
+    try {
+      const result = withEnv({ FAB_STATE_DIR: stateDir }, () => runDoctor({ cwd: process.cwd() }));
+      const stateCheck = result.checks.find((c) => c.name === 'state-dir');
+      expect(stateCheck?.status).toBe('fail');
+      expect(result.ok).toBe(false);
+    } finally {
+      fs.rmSync(path.dirname(stateDir), { recursive: true, force: true });
+    }
   });
 
   it('reports node-version >= 20 as ok', () => {
@@ -171,18 +181,19 @@ describe('fab doctor — CLI', () => {
   });
 
   it('emits domain-failure envelope with data.ok:false when state dir is unwritable', async () => {
-    // Note: /proc/1 exists on Linux (CI runs there) and macOS dev machines
-    // both — chmod prevents writing in either case. If a future platform
-    // makes this path actually writable, this test will need a different
-    // unwritable path.
-    const r = await runFab(['doctor', '--json'], { env: { FAB_STATE_DIR: '/proc/1/cant-write' } });
-    // Per #18 outcome taxonomy: tool ran successfully but found problems.
-    expect(r.exitCode).toBe(1);
-    const env: any = parseSingleEnvelope(r.stdout);
-    expect(env.status).toBe('ok');
-    expect(env.data.ok).toBe(false);
-    const stateCheck = env.data.checks.find((c: any) => c.name === 'state-dir');
-    expect(stateCheck.status).toBe('fail');
+    const stateDir = tmpFile('state-dir-file-cli');
+    try {
+      const r = await runFab(['doctor', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      // Per #18 outcome taxonomy: tool ran successfully but found problems.
+      expect(r.exitCode).toBe(1);
+      const env: any = parseSingleEnvelope(r.stdout);
+      expect(env.status).toBe('ok');
+      expect(env.data.ok).toBe(false);
+      const stateCheck = env.data.checks.find((c: any) => c.name === 'state-dir');
+      expect(stateCheck.status).toBe('fail');
+    } finally {
+      fs.rmSync(path.dirname(stateDir), { recursive: true, force: true });
+    }
   });
 
   it('default-tier run completes in <2s on a healthy install (when fast)', async () => {

--- a/src/cli/fab.ts
+++ b/src/cli/fab.ts
@@ -865,6 +865,12 @@ withJsonOptions(adapter
 
     if (result.ok) {
       console.log(`[fab adapter validate] ✅ ${result.className} (${result.type}) — all required methods present`);
+      recordCommand({
+        command: 'adapter-validate',
+        lastRoot: path.dirname(path.resolve(filePath)),
+        lastRootKind: 'persistent',
+        lastPhase: 'VALIDATE',
+      });
       emitOk('adapter-validate', {
         ok: true,
         type: result.type,
@@ -876,6 +882,13 @@ withJsonOptions(adapter
       for (const e of result.errors) {
         console.error(`  - ${e.kind}: ${e.expected}${e.line ? ` (line ${e.line})` : ''}`);
       }
+      recordCommand({
+        command: 'adapter-validate',
+        lastRoot: path.dirname(path.resolve(filePath)),
+        lastRootKind: 'persistent',
+        lastPhase: 'VALIDATE',
+        lastFailure: { phase: 'VALIDATE', message: `${result.errors.length} validation error(s) on ${result.className}` },
+      });
       emitDomainFailure('adapter-validate', {
         ok: false,
         type: result.type,

--- a/src/cli/state.test.ts
+++ b/src/cli/state.test.ts
@@ -15,6 +15,13 @@ function makeStateDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'fab-state-'));
 }
 
+function makeStateFile(): string {
+  const dir = makeStateDir();
+  const file = path.join(dir, 'not-a-directory');
+  fs.writeFileSync(file, 'x');
+  return file;
+}
+
 const SAMPLE_STATE: FabState = {
   lastRoot: '/tmp/foo',
   lastIteration: 1,
@@ -183,7 +190,12 @@ describe('recordCommand', () => {
   });
 
   it('does not throw when state dir is unwritable', () => {
-    process.env.FAB_STATE_DIR = '/proc/1/cant-write-here';
-    expect(() => recordCommand({ command: 'seed' })).not.toThrow();
+    const stateDir = makeStateFile();
+    try {
+      process.env.FAB_STATE_DIR = stateDir;
+      expect(() => recordCommand({ command: 'seed' })).not.toThrow();
+    } finally {
+      fs.rmSync(path.dirname(stateDir), { recursive: true, force: true });
+    }
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -372,3 +372,65 @@ describe('Docs accuracy — CLAUDE.md decision tree references real commands', (
     expect(count).toBeGreaterThanOrEqual(8);
   });
 });
+
+// ---------------------------------------------------------------------------
+// MCP timeout precedence — release-readiness gate (added per #26 reviewer feedback)
+// ---------------------------------------------------------------------------
+
+describe('MCP timeout precedence — release-readiness gate', () => {
+  // Reviewer-flagged that the original release-readiness suite did not catch
+  // the runner timeout NaN bug or the FAB_MCP_TIMEOUT_MS bypass. These end-
+  // to-end checks lock both paths into the integration suite so future
+  // regressions in either layer fail this PR's gate, not a per-PR review.
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { runFabCommand } = require(path.join(REPO_ROOT, 'dist', 'mcp', 'runner.js'));
+
+  it('runFabCommand({}) completes (no NaN-immediate-timeout regression)', async () => {
+    const stateDir = tmpStateDir();
+    try {
+      // Direct library call with NEITHER opts.timeoutMs NOR FAB_MCP_TIMEOUT_MS env.
+      // Must use the 30s default and complete normally — pre-fix this hit
+      // setTimeout(NaN) and timed out synchronously.
+      const original = process.env.FAB_MCP_TIMEOUT_MS;
+      delete process.env.FAB_MCP_TIMEOUT_MS;
+      try {
+        const r = await runFabCommand(['status'], { env: { FAB_STATE_DIR: stateDir } });
+        expect(r.timedOut).toBe(false);
+        expect((r.envelope as { command: string }).command).toBe('status');
+      } finally {
+        if (original !== undefined) process.env.FAB_MCP_TIMEOUT_MS = original;
+      }
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('FAB_MCP_TIMEOUT_MS reaches the runner via MCP server tool calls', async () => {
+    // Pre-fix: server passed tool.defaultTimeoutMs straight through to
+    // runFabCommand, ignoring the env. Now: env applies between per-call
+    // input.timeout_ms and tool.defaultTimeoutMs.
+    //
+    // We assert the high-env case completes cleanly (pre-fix would have
+    // also completed because tool.defaultTimeoutMs of 30s was used; but
+    // combined with the unit suite in #36 + the resolveEnvTimeoutMs
+    // export wired into src/index.ts, the integration test serves as
+    // the end-to-end smoke that the env path isn't broken at the seam.)
+    const stateDir = tmpStateDir();
+    try {
+      const responses = await rpcRoundTrip(
+        [
+          initReq(1),
+          callReq(2, 'stf_status', {}),
+        ],
+        { env: { FAB_STATE_DIR: stateDir, FAB_MCP_TIMEOUT_MS: '60000' } },
+      );
+      const tool = responses[1].result as { isError?: boolean; content: Array<{ text: string }> };
+      expect(tool.isError).not.toBe(true);
+      const env: any = JSON.parse(tool.content[0].text);
+      expect(env.status).toBe('ok');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,374 @@
+// v0.4.0 integration + release-readiness verification (#26).
+//
+// Per-ticket tests cover individual command surfaces. This suite owns the
+// cross-ticket concerns:
+//   - End-to-end CLI flow (init → scaffold → validate → doctor → smoke → status → inspect)
+//   - End-to-end MCP flow via fab-mcp (mirrors CLI, verifies parity)
+//   - Backward-compat: legacy text-mode framing snapshots still pass
+//   - Release readiness: npm pack + install in temp dir + npx fab-mcp round-trip
+//   - Taxonomy-conformance lint (static check on source files)
+//   - Docs accuracy: every command in CLAUDE.md decision tree exists
+
+import { spawn, ChildProcess, execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runFab, parseSingleEnvelope } from './cli/__test-helpers__/cli-runner';
+import { TOOL_NAMES } from './mcp/server';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `stf-int-${prefix}-`));
+}
+function tmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'stf-int-state-'));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end CLI flow (the chain a new-product onboarding agent would walk)
+// ---------------------------------------------------------------------------
+
+describe('E2E — CLI agent flow', () => {
+  it('init → scaffold → validate → doctor → status passes end-to-end', async () => {
+    const consumer = tmpDir('e2e-cli');
+    const stateDir = tmpStateDir();
+    try {
+      // 1. init
+      const init = await runFab(['init', '--dir', consumer, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(init.exitCode).toBe(0);
+      const initEnv: any = parseSingleEnvelope(init.stdout);
+      expect(initEnv.data.filesCreated.length).toBe(10);
+
+      // 2. scaffold an extra adapter (override existing)
+      const scaffold = await runFab([
+        'adapter', 'scaffold', 'reporter',
+        '--out', path.join(consumer, 'src/adapters/MyReporter.ts'),
+        '--force', '--json',
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      expect(scaffold.exitCode).toBe(0);
+
+      // 3. validate one of the generated stubs
+      const validate = await runFab([
+        'adapter', 'validate',
+        path.join(consumer, 'src/adapters/MyReporter.ts'),
+        '--json',
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      expect(validate.exitCode).toBe(0);
+      const validateEnv: any = parseSingleEnvelope(validate.stdout);
+      expect(validateEnv.data.ok).toBe(true);
+      expect(validateEnv.data.type).toBe('reporter');
+
+      // 4. doctor on a fresh project — config present, optional peers should
+      //    only warn (no provider env, no provider class refs).
+      const doctor = await runFab(['doctor', '--json'], {
+        cwd: consumer,
+        env: { FAB_STATE_DIR: stateDir },
+      });
+      // doctor returns exit 0 only if all required deps present in cwd's
+      // node_modules. The temp consumer has nothing installed — doctor
+      // will report fail for missing required runtime deps. That's
+      // expected behavior (proves doctor catches missing deps), so we
+      // assert the envelope shape rather than success.
+      const doctorEnv: any = parseSingleEnvelope(doctor.stdout);
+      expect(doctorEnv.command).toBe('doctor');
+      expect(doctorEnv.status).toBe('ok');
+      expect(Array.isArray(doctorEnv.data.checks)).toBe(true);
+
+      // 5. status reflects the chain
+      const status = await runFab(['status', '--json'], { env: { FAB_STATE_DIR: stateDir } });
+      expect(status.exitCode).toBe(0);
+      const statusEnv: any = parseSingleEnvelope(status.stdout);
+      expect(statusEnv.data.state).toBe('populated');
+      expect(statusEnv.data.lastCommand).toBe('doctor');
+      expect(statusEnv.data.lastPhase).toBe('DOCTOR');
+    } finally {
+      fs.rmSync(consumer, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('every step in the chain emits a parseable envelope (stdout-purity)', async () => {
+    const consumer = tmpDir('purity');
+    const stateDir = tmpStateDir();
+    try {
+      const steps = [
+        ['init', '--dir', consumer],
+        ['adapter', 'scaffold', 'app', '--out', path.join(consumer, 'src/adapters/MyAppAdapter.ts'), '--force'],
+        ['adapter', 'validate', path.join(consumer, 'src/adapters/MyAppAdapter.ts')],
+        ['status'],
+      ];
+      for (const args of steps) {
+        const r = await runFab([...args, '--json'], { env: { FAB_STATE_DIR: stateDir } });
+        // parseSingleEnvelope throws if stdout has anything other than one envelope.
+        const env = parseSingleEnvelope(r.stdout);
+        expect(env).toBeDefined();
+      }
+    } finally {
+      fs.rmSync(consumer, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E MCP flow — same chain, via fab-mcp
+// ---------------------------------------------------------------------------
+
+const MCP_SERVER = path.join(REPO_ROOT, 'dist', 'mcp', 'server.js');
+
+beforeAll(() => {
+  if (!fs.existsSync(MCP_SERVER)) {
+    execSync('npm run build', { cwd: REPO_ROOT, stdio: 'inherit' });
+  }
+});
+
+interface JsonRpcResponse { jsonrpc: '2.0'; id: number | string; result?: unknown; error?: unknown }
+
+async function rpcRoundTrip(
+  requests: Array<{ id?: number | string }>,
+  opts: { cwd?: string; env?: Record<string, string> } = {},
+): Promise<JsonRpcResponse[]> {
+  const child: ChildProcess = spawn(process.execPath, [MCP_SERVER], {
+    cwd: opts.cwd ?? REPO_ROOT,
+    env: { ...process.env, ...opts.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const expectedIds = new Set(requests.map((r) => r.id).filter((id): id is number | string => id !== undefined));
+  let buffer = '';
+  const responses = new Map<number | string, JsonRpcResponse>();
+
+  child.stderr!.on('data', () => { /* swallow */ });
+  child.stdin!.write(requests.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  return new Promise<JsonRpcResponse[]>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`mcp roundtrip timeout. Got ${responses.size}/${expectedIds.size}; tail=${buffer.slice(-200)}`));
+    }, 30_000);
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as JsonRpcResponse;
+          if (parsed.id !== undefined && expectedIds.has(parsed.id)) {
+            responses.set(parsed.id, parsed);
+            if (responses.size === expectedIds.size) {
+              clearTimeout(timer);
+              child.kill();
+              resolve(requests
+                .filter((r): r is { id: number | string } => r.id !== undefined)
+                .map((r) => responses.get(r.id)!));
+              return;
+            }
+          }
+        } catch { /* not JSON */ }
+      }
+    });
+  });
+}
+
+const initReq = (id = 1): object => ({
+  jsonrpc: '2.0', id, method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+});
+const callReq = (id: number, name: string, args: Record<string, unknown> = {}): object => ({
+  jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args },
+});
+const envOf = (resp: JsonRpcResponse): any => JSON.parse((resp.result as { content: Array<{ text: string }> }).content[0].text);
+
+describe('E2E — MCP agent flow', () => {
+  it('init → adapter_scaffold → adapter_validate → status via fab-mcp', async () => {
+    const consumer = tmpDir('e2e-mcp');
+    const stateDir = tmpStateDir();
+    try {
+      const adapterPath = path.join(consumer, 'src/adapters/MyReporter.ts');
+      // Send sequentially so each step's effect lands before the next runs
+      // (MCP server processes in parallel; this chain has data dependencies).
+      const initResp = await rpcRoundTrip([
+        initReq(1),
+        callReq(2, 'stf_init', { dir: consumer }),
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      const initEnv = envOf(initResp[1]);
+      expect(initEnv.data.filesCreated.length).toBe(10);
+
+      const scaffoldResp = await rpcRoundTrip([
+        initReq(1),
+        callReq(2, 'stf_adapter_scaffold', { type: 'reporter', out: adapterPath, force: true }),
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      const scaffoldEnv = envOf(scaffoldResp[1]);
+      expect(scaffoldEnv.data.type).toBe('reporter');
+
+      const validateResp = await rpcRoundTrip([
+        initReq(1),
+        callReq(2, 'stf_adapter_validate', { path: adapterPath }),
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      const validateEnv = envOf(validateResp[1]);
+      expect(validateEnv.data.ok).toBe(true);
+      expect(validateEnv.data.type).toBe('reporter');
+
+      const statusResp = await rpcRoundTrip([
+        initReq(1),
+        callReq(2, 'stf_status', {}),
+      ], { env: { FAB_STATE_DIR: stateDir } });
+      const statusEnv = envOf(statusResp[1]);
+      // Per #20, fab adapter validate command name in state is 'adapter-validate' (not 'adapter_validate').
+      expect(statusEnv.data.lastCommand).toBe('adapter-validate');
+    } finally {
+      fs.rmSync(consumer, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backward-compat — assert the legacy text framing snapshots still pass
+// ---------------------------------------------------------------------------
+
+describe('Backward-compat — legacy text framing', () => {
+  it('text-mode snapshot suite from #18 is wired and passing', () => {
+    // The snapshot suite lives at src/cli/text-mode.test.ts (added in #18).
+    // We assert it exists; jest runs it as part of the full suite.
+    const file = path.join(REPO_ROOT, 'src', 'cli', 'text-mode.test.ts');
+    expect(fs.existsSync(file)).toBe(true);
+    const source = fs.readFileSync(file, 'utf8');
+    expect(source).toMatch(/backward-compat snapshots/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release readiness — npm pack + install + npx fab-mcp from outside package
+// ---------------------------------------------------------------------------
+
+describe('Release readiness — npm pack + install + npx fab-mcp', () => {
+  // This test is the canary for the #27 path-resolution bug class. It runs
+  // a real `npm pack`, installs the tarball into a fresh temp dir, then
+  // spawns `npx fab-mcp` from THAT dir (not from the package root) and
+  // expects tools/list to return the 19 tools.
+  //
+  // Slow (~20-30s for npm pack + install). Tagged so it can be skipped with
+  // `jest --testPathIgnorePatterns=integration` if needed.
+  it('packed tarball installs and fab-mcp works from a fresh consumer dir', async () => {
+    const tarballDir = tmpDir('pack');
+    const consumerDir = tmpDir('consumer');
+    try {
+      // Build first if dist is stale.
+      execSync('npm run build', { cwd: REPO_ROOT, stdio: 'pipe' });
+
+      // Pack into tarballDir.
+      execSync(`npm pack --pack-destination ${tarballDir}`, { cwd: REPO_ROOT, stdio: 'pipe' });
+      const tarballs = fs.readdirSync(tarballDir).filter((f) => f.endsWith('.tgz'));
+      expect(tarballs.length).toBe(1);
+      const tarball = path.join(tarballDir, tarballs[0]);
+
+      // Init a fresh consumer project + install.
+      execSync('npm init -y', { cwd: consumerDir, stdio: 'pipe' });
+      execSync(`npm install ${tarball}`, { cwd: consumerDir, stdio: 'pipe' });
+
+      // Ensure fab-mcp binary is available.
+      const fabMcp = path.join(consumerDir, 'node_modules', '.bin', 'fab-mcp');
+      expect(fs.existsSync(fabMcp)).toBe(true);
+
+      // Spawn from consumer cwd (NOT from package root) and round-trip
+      // tools/list. This is the path-resolution regression test for #27.
+      const child = spawn(process.execPath, [fabMcp], {
+        cwd: consumerDir,
+        env: { ...process.env, FAB_STATE_DIR: tmpStateDir() },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let buffer = '';
+      const responses: JsonRpcResponse[] = [];
+      child.stdout!.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try { responses.push(JSON.parse(trimmed) as JsonRpcResponse); } catch { /* skip */ }
+        }
+      });
+      child.stderr!.on('data', () => { /* swallow */ });
+
+      child.stdin!.write(JSON.stringify(initReq(1)) + '\n');
+      child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }) + '\n');
+
+      const result = await new Promise<JsonRpcResponse | null>((resolve) => {
+        const timer = setTimeout(() => { child.kill('SIGKILL'); resolve(null); }, 15_000);
+        const poll = setInterval(() => {
+          const list = responses.find((r) => r.id === 2);
+          if (list) {
+            clearTimeout(timer);
+            clearInterval(poll);
+            child.kill();
+            resolve(list);
+          }
+        }, 100);
+      });
+
+      expect(result).not.toBeNull();
+      const tools = (result!.result as { tools: Array<{ name: string }> }).tools;
+      expect(tools).toHaveLength(19);
+    } finally {
+      fs.rmSync(tarballDir, { recursive: true, force: true });
+      fs.rmSync(consumerDir, { recursive: true, force: true });
+    }
+  }, 90_000);
+});
+
+// ---------------------------------------------------------------------------
+// Taxonomy-conformance lint — static check on source files
+// ---------------------------------------------------------------------------
+
+describe('Taxonomy conformance — no command emits status:"error" for expected domain failures', () => {
+  // Static check: scan src/cli/fab.ts for emit* calls and assert the
+  // domain-failure paths use emitDomainFailure (not emitError). The CLI
+  // commands tested here are the ones with domain-failure modes.
+  const fabSource = fs.readFileSync(path.join(REPO_ROOT, 'src', 'cli', 'fab.ts'), 'utf8');
+
+  it('check (below threshold) uses emitDomainFailure', () => {
+    // Find the check command's domain-failure handler — should call emitDomainFailure.
+    expect(fabSource).toMatch(/emitDomainFailure\('check'/);
+  });
+
+  it('flows (failed > 0) uses emitDomainFailure', () => {
+    expect(fabSource).toMatch(/emitDomainFailure\('flows'/);
+  });
+
+  it('adapter-validate (validation failures) uses emitDomainFailure', () => {
+    expect(fabSource).toMatch(/emitDomainFailure\('adapter-validate'/);
+  });
+
+  it('doctor (any check fails) uses emitDomainFailure', () => {
+    expect(fabSource).toMatch(/emitDomainFailure\('doctor'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Docs accuracy — every command in CLAUDE.md decision tree exists
+// ---------------------------------------------------------------------------
+
+describe('Docs accuracy — CLAUDE.md decision tree references real commands', () => {
+  const claudeMd = fs.readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8');
+
+  it('every fab command in the decision tree maps to an MCP tool name', () => {
+    // Decision tree rows have format: | ... | `fab xxx` | `stf_yyy` |
+    const rows = claudeMd.matchAll(/\|\s*`(fab [a-z][^`]*)`\s*\|\s*`(stf_[a-z_]+)`\s*\|/g);
+    let count = 0;
+    for (const m of rows) {
+      const stfTool = m[2];
+      expect(TOOL_NAMES).toContain(stfTool);
+      count++;
+    }
+    // Sanity: we expect ~10 rows in the tree.
+    expect(count).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -406,16 +406,14 @@ describe('MCP timeout precedence — release-readiness gate', () => {
     }
   });
 
-  it('FAB_MCP_TIMEOUT_MS reaches the runner via MCP server tool calls', async () => {
+  it('FAB_MCP_TIMEOUT_MS reaches the runner via MCP server tool calls (low-timeout discriminating test)', async () => {
     // Pre-fix: server passed tool.defaultTimeoutMs straight through to
-    // runFabCommand, ignoring the env. Now: env applies between per-call
-    // input.timeout_ms and tool.defaultTimeoutMs.
-    //
-    // We assert the high-env case completes cleanly (pre-fix would have
-    // also completed because tool.defaultTimeoutMs of 30s was used; but
-    // combined with the unit suite in #36 + the resolveEnvTimeoutMs
-    // export wired into src/index.ts, the integration test serves as
-    // the end-to-end smoke that the env path isn't broken at the seam.)
+    // runFabCommand, ignoring the env. Setting FAB_MCP_TIMEOUT_MS=1 here is
+    // the discriminating case — pre-fix the server would have used
+    // tool.defaultTimeoutMs (30s) for stf_status and the call would have
+    // SUCCEEDED. Post-fix the 1ms env value reaches the runner, fires
+    // setTimeout(1) which kills the spawned subprocess almost immediately,
+    // and the result is a synthesized TIMEOUT envelope.
     const stateDir = tmpStateDir();
     try {
       const responses = await rpcRoundTrip(
@@ -423,12 +421,15 @@ describe('MCP timeout precedence — release-readiness gate', () => {
           initReq(1),
           callReq(2, 'stf_status', {}),
         ],
-        { env: { FAB_STATE_DIR: stateDir, FAB_MCP_TIMEOUT_MS: '60000' } },
+        { env: { FAB_STATE_DIR: stateDir, FAB_MCP_TIMEOUT_MS: '1' } },
       );
       const tool = responses[1].result as { isError?: boolean; content: Array<{ text: string }> };
-      expect(tool.isError).not.toBe(true);
+      // TIMEOUT is an infrastructure error — server returns isError:true with
+      // the synthesized envelope from runner.ts (code: TIMEOUT).
+      expect(tool.isError).toBe(true);
       const env: any = JSON.parse(tool.content[0].text);
-      expect(env.status).toBe('ok');
+      expect(env.status).toBe('error');
+      expect(env.error.code).toBe('TIMEOUT');
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -383,7 +383,7 @@ describe('MCP timeout precedence — release-readiness gate', () => {
   // to-end checks lock both paths into the integration suite so future
   // regressions in either layer fail this PR's gate, not a per-PR review.
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { runFabCommand } = require(path.join(REPO_ROOT, 'dist', 'mcp', 'runner.js'));
 
   it('runFabCommand({}) completes (no NaN-immediate-timeout regression)', async () => {


### PR DESCRIPTION
## Summary

Cross-ticket suite that owns the concerns no single child ticket covers. Closes the v0.4.0 epic (#17).

Closes #26. Stacked on #25 + #27.

## What's in

### End-to-end CLI flow

\`init → adapter scaffold → adapter validate → doctor → status\` against a fresh temp consumer dir. Asserts envelope shape at every step + stdout-purity.

### End-to-end MCP flow

Same chain via \`fab-mcp\` stdio (sequential calls so chained data-dependencies land in order).

### Backward-compat snapshot suite

Text-mode framing locked down by #18 still passes — \`src/cli/text-mode.test.ts\` referenced explicitly.

### Release readiness — \`npm pack\` round-trip

The big one for #27. \`npm pack\` → install tarball into a fresh temp dir → spawn \`npx fab-mcp\` from THAT dir (NOT the package root) → assert \`tools/list\` returns the 19 tools. Catches the path-resolution bug class that bit #27 originally.

### Taxonomy-conformance lint

Static check on \`src/cli/fab.ts\` source: every command's domain-failure path uses \`emitDomainFailure\` (NOT \`emitError\`). Prevents future commands from overloading \`status: "error"\` for expected validation failures.

### Docs accuracy

Parses the \`CLAUDE.md\` decision tree and asserts every \`stf_*\` MCP tool name maps to a real entry in \`TOOL_NAMES\`.

## Bug surfaced + fixed (in this PR)

\`fab adapter validate\` (#23) didn't call \`recordCommand\`, so \`fab status\` showed the previous command after a validate run. Added \`recordCommand\` to both success + domain-failure paths. \`lastPhase = 'VALIDATE'\`.

This is exactly the kind of cross-ticket gap #26 was designed to catch.

## CHANGELOG

Added \`[0.4.0] — agent-friendly surface\` entry covering all of #18–#27.

## Test plan

- [x] \`npm test\` — 514/514 pass (+10 new integration tests)
- [x] \`npm run build\` — clean
- [x] \`npm run check:boundary\` — pass
- [x] Real \`npm pack\` + install + \`npx fab-mcp\` round-trip (~16s, included)
- [x] All 5 categories of integration test (CLI E2E / MCP E2E / backward-compat / release / taxonomy / docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)