### PR TITLE
docs: align README + quickstart + overview + adapter-contract with v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@
 
 ---
 
-Synthetic Test Fabric is a TypeScript framework that replaces hand-written test maintenance with a closed loop: generate synthetic users → simulate their behavior → extract observed paths → generate and execute browser flows → score results → feed findings into the next iteration.
+Synthetic Test Fabric is a TypeScript framework that replaces hand-written test
+maintenance with a closed loop: generate synthetic users → simulate their behavior →
+extract observed paths → generate and execute browser flows → score results → feed
+findings into the next iteration.
 
 You write adapters for your app once. The framework does the rest.
+
+> **New in v0.4.0** — agent-friendly surface. `fab init` scaffolds a working project
+> in seconds. `fab-mcp` exposes every command as a native MCP tool so Claude Code (or
+> any MCP client) can drive STF without bash + JSON parsing. See
+> [What's new](#whats-new-in-v040).
 
 ---
 
@@ -25,109 +33,69 @@ npx playwright install chromium
 npx tsx demo/run.ts
 ```
 
-No external services. No API keys. Full loop against a static HTML taskboard app — completes in under 30 seconds and produces a scored report.
+No external services. No API keys. Full loop against a static HTML taskboard app —
+completes in under 30 seconds and produces a scored report.
+
+---
+
+## Wire it into your product in 1 minute
+
+```bash
+npm install synthetic-test-fabric
+npx fab init                            # scaffolds fabric.config.ts + 8 adapter stubs
+npx fab doctor                          # verify env + peer deps are happy
+npx fab adapter validate src/adapters/MyAppAdapter.ts   # check one stub against the interface
+# ... edit src/adapters/*.ts to fill in the TODOs ...
+npx fab smoke --keep                    # bounded smoke check; prints what worked + what didn't
+npx fab status                          # "where am I?" between sessions
+```
+
+Every command has `--json` for scripts and CI gates. See [docs/cli-json-output.md](docs/cli-json-output.md).
+
+---
+
+## Drive it with Claude Code (or any MCP client)
+
+`fab-mcp` is a Model Context Protocol server that exposes every `fab` command as a
+native MCP tool. After `npm install synthetic-test-fabric`, add it to your MCP
+config (`~/.claude/.mcp.json` or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "fab": { "command": "fab-mcp" }
+  }
+}
+```
+
+Then ask Claude things like:
+
+- *"Set up STF for this product"* → `stf_init` + `stf_doctor`
+- *"Add a Slack reporter adapter"* → `stf_adapter_scaffold reporter` + edit + `stf_adapter_validate`
+- *"Why did the score drop?"* → `stf_status` + `stf_inspect` against the last loop root
+- *"Test the new feature"* → `stf_smoke`
+
+Full install and tool reference: [docs/mcp-install.md](docs/mcp-install.md).
+Decision tree mapping intents to commands: [CLAUDE.md](CLAUDE.md).
 
 ---
 
 ## The problem it solves
 
-Playwright is an executor. It runs specs you wrote against state you set up manually. That model breaks when you have hundreds of flows, a changing product, and no time to write tests for every new path.
+Playwright is an executor. It runs specs you wrote against state you set up manually.
+That model breaks when you have hundreds of flows, a changing product, and no time
+to write tests for every new path.
 
-Synthetic Test Fabric inverts this: synthetic users navigate your app autonomously, their paths become the test corpus, and the corpus grows automatically. Coverage is a function of runtime, not headcount.
+Synthetic Test Fabric inverts this: synthetic users navigate your app autonomously,
+their paths become the test corpus, and the corpus grows automatically. Coverage is
+a function of runtime, not headcount.
 
 ```
 SEED → VERIFY → RUN → ANALYZE → GENERATE_FLOWS → TEST → SCORE → FEEDBACK → repeat
 ```
 
-Each iteration, the system finds new paths, generates new specs, scores what it has, and uses that score to steer the next iteration toward gaps.
-
----
-
-## Install
-
-```bash
-npm install synthetic-test-fabric
-```
-
-**Node.js 20+ · TypeScript 5+**
-
-The packaged demo uses Playwright directly. Install `@playwright/test` when you
-want to run `demo/run.ts` from the npm tarball.
-
-Optionally add the Lisa MCP server for LLM-driven element inference in the flow generation step:
-
-```bash
-npm install @kaneshir/lisa-mcp
-```
-
----
-
-## Your first loop in 5 minutes
-
-**1. Implement the eight adapter interfaces:**
-
-```typescript
-import {
-  AppAdapter, SimulationAdapter, ScoringAdapter, FeedbackAdapter,
-  BrowserAdapter, MemoryAdapter, Reporter, ScenarioPlanner,
-} from 'synthetic-test-fabric';
-
-// Start with stubs — the orchestrator surfaces errors at each step
-export class MyAppAdapter implements AppAdapter {
-  async seed(iterRoot, config)       { /* write mini-sim-export.json + lisa.db */ }
-  async verify(iterRoot)             { /* throw if required aliases missing */ }
-  async reset(iterRoot)              {}
-  async validateEnvironment()        { return { healthy: true, errors: [], warnings: [] }; }
-  async importRun(iterRoot, dbUrl)   {}
-}
-```
-
-See `demo/adapters.ts` for a complete working reference — every method implemented, no external dependencies.
-
-**2. Wire the orchestrator:**
-
-```typescript
-import { FabricOrchestrator, makeLoopId } from 'synthetic-test-fabric';
-
-const orchestrator = new FabricOrchestrator({
-  app:        new MyAppAdapter(),
-  simulation: new MySimulationAdapter(),
-  scoring:    new MyScoringAdapter(),
-  feedback:   new MyFeedbackAdapter(),
-  memory:     new MyMemoryAdapter(),
-  browser:    new MyBrowserAdapter(),
-  reporters:  [new ConsoleReporter()],
-  planner:    new MyScenarioPlanner(),
-});
-
-await orchestrator.run({
-  loopId:                 makeLoopId(),
-  iterations:             1,
-  ticks:                  5,
-  liveLlm:                false,
-  allowRegressionFailures: false,
-  seekers:                1,
-  employers:              1,
-  employees:              0,
-});
-```
-
-**Or use the `fab` CLI with a config file:**
-
-```typescript
-// fabric.config.ts
-import { FabricConfig } from 'synthetic-test-fabric';
-export default {
-  adapters: { app: new MyAppAdapter(), /* ... */ },
-  defaults:  { iterations: 3, ticks: 10 },
-} satisfies FabricConfig;
-```
-
-```bash
-npx fab orchestrate          # run the full loop
-npx fab smoke                # single iteration smoke check
-npx fab check --root /tmp/fabric-loop/iter-001 --threshold 8  # CI score gate
-```
+Each iteration the system finds new paths, generates new specs, scores what it has,
+and uses that score to steer the next iteration toward gaps.
 
 ---
 
@@ -144,7 +112,31 @@ After each iteration the framework produces a six-dimension score:
 | `regression_health` | Previously passing flows still pass |
 | `flow_coverage` | Playwright pass rate across all executed flows |
 
-The score drives the next iteration — low `novelty` steers the planner toward unexplored scenarios; low `regression_health` flags regressions immediately.
+The score drives the next iteration — low `coverage_delta` steers the planner toward
+unexplored scenarios; low `regression_health` flags regressions immediately.
+
+---
+
+## What's new in v0.4.0
+
+The CLI surface a Claude Code (or similar) agent can drive end-to-end. Same engine
+as v0.3.x; new ways to operate it.
+
+| Command | What it does |
+|---------|--------------|
+| `fab init [--dir <path>]` | Scaffold `fabric.config.ts` + 8 adapter stubs into a target directory |
+| `fab adapter scaffold <type>` | Generate one stub on demand for any of the 8 adapter types |
+| `fab adapter validate <path>` | Type-check an adapter file against its target interface |
+| `fab doctor [--deep]` | Pre-flight env + peer-dep health check (LLM provider SDKs, Playwright browsers, writable state dir) |
+| `fab status` | Show the most recent run outcome from `~/.fab/state.json` |
+| `fab inspect --root <dir>` | Structured `RunRootSummary` (phase, score, flows, recent behavior events) |
+| `fab-mcp` (binary) | MCP server wrapping all 19 commands as `stf_*` tools |
+
+Plus: `--json` envelope on every command, library exports for `scaffoldProject`,
+`scaffoldAdapter`, `validateAdapter`, `runDoctor`, `inspectRunRoot`, `runFabCommand`,
+`createMcpServer` — see [docs/cli-json-output.md](docs/cli-json-output.md).
+
+Full changelog: [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
@@ -154,7 +146,7 @@ The score drives the next iteration — low `novelty` steers the planner toward 
 |---------|-----------|
 | **Flakiness tracking** | `FlakinessTracker` persists per-flow failure rates; failing flows get quarantined automatically |
 | **Adversarial personas** | Set `adversarial: true` in persona YAML; the agent probes validation gaps and unauthorized routes |
-| **CI score gate** | `fab check --threshold 8.0` or `assertScoreThreshold(score, 8.0)` in your pipeline |
+| **CI score gate** | `fab check --threshold 8.0 --json` — exit 1 + `data.ok: false` on threshold failure |
 | **Slack reporting** | `SlackReporter` posts a score summary + dimension breakdown to any webhook |
 | **Visual regression** | `VisualRegression.capture/compare` with pixelmatch; baselines managed via `fab baseline` |
 | **HTML trend report** | `HtmlReporter` generates a self-contained report with Chart.js trend across the last 30 iterations |
@@ -166,13 +158,21 @@ The score drives the next iteration — low `novelty` steers the planner toward 
 
 ## How it relates to `@kaneshir/lisa-mcp`
 
-`@kaneshir/lisa-mcp` is an optional peer package that ships a precompiled Lisa MCP server binary. It has two integration paths:
+`@kaneshir/lisa-mcp` is an optional peer package that ships a precompiled Lisa MCP
+server binary. (Note: this is **separate from `fab-mcp`** — Lisa MCP drives flow
+generation against your live app; `fab-mcp` exposes the `fab` CLI to your IDE agent.)
+Lisa MCP has two integration paths:
 
 **Path 1 — BrowserAdapter element inference (original)**
-Your `BrowserAdapter.runSpecs()` calls `buildLisaMcpCommand()`, spawns the MCP server, and lets an LLM use `lisa_explore_screen` / `lisa_tap_key` tools to discover interactive elements and generate Playwright spec steps from actual observations.
+Your `BrowserAdapter.runSpecs()` calls `buildLisaMcpCommand()`, spawns the MCP server,
+and lets an LLM use `lisa_explore_screen` / `lisa_tap_key` tools to discover
+interactive elements and generate Playwright spec steps from actual observations.
 
 **Path 2 — Agentic loop via `LISA_LLM_PROVIDER` (v0.3.0+)**
-Set `LISA_LLM_PROVIDER=anthropic|openai|gemini` and the framework automatically spawns the binary as an `AgentLoopProvider`. The LLM drives a full multi-turn tool-call loop — no custom `BrowserAdapter` wiring needed. The binary's tool list is fetched at runtime; tool calls are dispatched back via MCP `tools/call`.
+Set `LISA_LLM_PROVIDER=anthropic|openai|gemini` and the framework automatically
+spawns the binary as an `AgentLoopProvider`. The LLM drives a full multi-turn
+tool-call loop — no custom `BrowserAdapter` wiring needed. The binary's tool list
+is fetched at runtime; tool calls are dispatched back via MCP `tools/call`.
 
 ```bash
 # Zero-config agentic loop with OpenAI
@@ -184,9 +184,15 @@ npm install @kaneshir/lisa-mcp @anthropic-ai/sdk
 LISA_LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-... npx fab orchestrate
 ```
 
-Without `@kaneshir/lisa-mcp`: your `BrowserAdapter` supplies its own selectors — fully supported. `LISA_LLM_PROVIDER` requires it.
+Without `@kaneshir/lisa-mcp`: your `BrowserAdapter` supplies its own selectors —
+fully supported. `LISA_LLM_PROVIDER` requires it.
 
-See [docs/lisa-mcp.md](docs/lisa-mcp.md) and [docs/env-vars.md](docs/env-vars.md) for full integration details.
+`fab doctor` warns about missing optional peer deps and escalates to **fail** when
+`LISA_LLM_PROVIDER` is set or your config references the agent loop — so you'll
+catch missing pieces before the loop fails.
+
+See [docs/lisa-mcp.md](docs/lisa-mcp.md) and [docs/env-vars.md](docs/env-vars.md)
+for full integration details.
 
 ---
 
@@ -197,8 +203,11 @@ See [docs/lisa-mcp.md](docs/lisa-mcp.md) and [docs/env-vars.md](docs/env-vars.md
 | [docs/prerequisites.md](docs/prerequisites.md) | Everyone | **Start here** — what STF actually requires to be effective, honest cost estimates, realistic timeline |
 | [docs/testability-standard.md](docs/testability-standard.md) | Everyone | **Required self-assessment** — pass/fail checklist for all 8 adapters; determines whether your product is ready for integration |
 | [docs/overview.md](docs/overview.md) | Everyone | Framework model, loop phases, adapters, lisa-mcp, scoring |
+| [docs/quickstart.md](docs/quickstart.md) | Engineers | Step-by-step wiring guide using `fab init` — zero to working loop |
+| [docs/cli-json-output.md](docs/cli-json-output.md) | Engineers, agents | The `--json` envelope contract, outcome taxonomy, caller rules — read this once before scripting against `fab` |
+| [docs/mcp-install.md](docs/mcp-install.md) | Engineers, agents | `fab-mcp` install + the 19 `stf_*` tools + outcome translation + timeout policy |
+| [CLAUDE.md](CLAUDE.md) | Claude Code users | Decision tree mapping user intents to `fab` commands and `stf_*` MCP tools |
 | [docs/example-walkthrough.md](docs/example-walkthrough.md) | Everyone | One full iteration, file by file — what actually gets written and why |
-| [docs/quickstart.md](docs/quickstart.md) | Engineers | Step-by-step wiring guide — zero to working loop |
 | [docs/architecture.md](docs/architecture.md) | Architects | Full call chain, lisa.db schema, MCP integration, feedback loop design |
 | [docs/adapter-contract.md](docs/adapter-contract.md) | Engineers | Every interface, every method, with inline guidance |
 | [docs/run-root-contract.md](docs/run-root-contract.md) | Engineers | Artifact layout and environment variable contract |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Full changelog: [CHANGELOG.md](CHANGELOG.md).
 |---------|-----------|
 | **Flakiness tracking** | `FlakinessTracker` persists per-flow failure rates; failing flows get quarantined automatically |
 | **Adversarial personas** | Set `adversarial: true` in persona YAML; the agent probes validation gaps and unauthorized routes |
-| **CI score gate** | `fab check --threshold 8.0 --json` — exit 1 + `data.ok: false` on threshold failure |
+| **CI score gate** | `fab check --root <loop> --threshold 8.0 --json` — exit 1 + `data.ok: false` on threshold failure |
 | **Slack reporting** | `SlackReporter` posts a score summary + dimension breakdown to any webhook |
 | **Visual regression** | `VisualRegression.capture/compare` with pixelmatch; baselines managed via `fab baseline` |
 | **HTML trend report** | `HtmlReporter` generates a self-contained report with Chart.js trend across the last 30 iterations |

--- a/docs/adapter-contract.md
+++ b/docs/adapter-contract.md
@@ -5,6 +5,17 @@ framework drives the loop; adapters do everything app-specific.
 
 All adapter interfaces are exported from `synthetic-test-fabric`.
 
+> **Don't write these from scratch.** Run `fab adapter scaffold <type>` to
+> generate a stub that compiles against the interface, then iterate using
+> `fab adapter validate <path>` to confirm your edits still satisfy the
+> contract. Both commands are documented in [quickstart.md §2](./quickstart.md).
+>
+> ```bash
+> fab adapter scaffold app --out src/adapters/MyAppAdapter.ts
+> # ... edit the generated TODO methods ...
+> fab adapter validate src/adapters/MyAppAdapter.ts
+> ```
+
 ---
 
 ## AppAdapter

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -74,15 +74,15 @@ scripts and CI. Outcome envelope is documented in
 [cli-json-output.md](./cli-json-output.md).
 
 ```bash
-fab init        # scaffold a new project
-fab smoke       # bounded check
-fab orchestrate # full loop
-fab status      # cross-run state
-fab inspect     # structured run-root summary
-fab doctor      # env + peer-dep health check
-fab adapter scaffold <type>     # generate one stub
-fab adapter validate <path>      # type-check it against the interface
-fab check --threshold N          # CI score gate
+fab init                              # scaffold a new project
+fab smoke                             # bounded check
+fab orchestrate                       # full loop
+fab status                            # cross-run state
+fab inspect --root <dir>              # structured run-root summary
+fab doctor                            # env + peer-dep health check
+fab adapter scaffold <type>           # generate one stub
+fab adapter validate <path>           # type-check it against the interface
+fab check --root <dir> --threshold N  # CI score gate
 ```
 
 **2. MCP server (`fab-mcp`)** — exposes every command as a typed `stf_*` tool

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -59,7 +59,49 @@ adapters you implement:
 | `ScenarioPlanner` | Recommend next scenario based on score |
 
 See [adapter-contract.md](./adapter-contract.md) for interface definitions and
-implementation guidance.
+implementation guidance. Use `fab adapter scaffold <type>` to generate a stub
+that compiles against the interface, and `fab adapter validate <path>` to
+check your edits in milliseconds without spinning up the full loop.
+
+---
+
+## How you operate it
+
+STF ships three peer surfaces — same engine underneath, three ways to drive it:
+
+**1. CLI (`fab`)** — primary interface. Every command accepts `--json` for
+scripts and CI. Outcome envelope is documented in
+[cli-json-output.md](./cli-json-output.md).
+
+```bash
+fab init        # scaffold a new project
+fab smoke       # bounded check
+fab orchestrate # full loop
+fab status      # cross-run state
+fab inspect     # structured run-root summary
+fab doctor      # env + peer-dep health check
+fab adapter scaffold <type>     # generate one stub
+fab adapter validate <path>      # type-check it against the interface
+fab check --threshold N          # CI score gate
+```
+
+**2. MCP server (`fab-mcp`)** — exposes every command as a typed `stf_*` tool
+for Claude Code (or any MCP client). Same envelope contract as the CLI; the
+server subprocess-wraps the CLI so the source of truth stays in one place. See
+[mcp-install.md](./mcp-install.md).
+
+**3. Library** — every operation has a typed JS export from
+`synthetic-test-fabric`:
+
+```ts
+import {
+  scaffoldProject, scaffoldAdapter, validateAdapter,
+  runDoctor, inspectRunRoot, runFabCommand,
+} from 'synthetic-test-fabric';
+```
+
+Useful when you want to embed STF inside your own tooling, IDE plugin, or
+custom dashboard rather than shelling out.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart: Wire the framework to your app
 
-This guide takes you from zero to a working fabric loop against your own app in
-under 10 minutes. It assumes you have already run the demo successfully.
+This guide takes you from zero to a working fabric loop against your own app
+in under 10 minutes. It assumes you've already run the demo successfully.
 
 > **Before you start:** Read [prerequisites.md](./prerequisites.md). A working
 > loop is not the same as an effective one. The prerequisites doc is honest about
@@ -9,11 +9,31 @@ under 10 minutes. It assumes you have already run the demo successfully.
 
 ---
 
-## 1. Install
+## 1. Install + scaffold
 
 ```bash
 npm install synthetic-test-fabric
+npx fab init                            # writes fabric.config.ts + 8 adapter stubs
+npx fab doctor                          # verify env, peer deps, writable state dir
 ```
+
+`fab init` creates:
+
+```
+fabric.config.ts                         (wired with all 8 adapters)
+src/adapters/MyAppAdapter.ts             (throws TODO on every required method)
+src/adapters/MySimulationAdapter.ts
+src/adapters/MyScoringAdapter.ts
+src/adapters/MyFeedbackAdapter.ts
+src/adapters/MyMemoryAdapter.ts
+src/adapters/MyBrowserAdapter.ts
+src/adapters/MyReporter.ts
+src/adapters/MyScenarioPlanner.ts
+flows/.gitkeep
+```
+
+The generated `fabric.config.ts` loads via `loadFabricConfig()` immediately —
+`fab doctor` won't blow up post-init.
 
 Peer requirements: Node.js 20+, TypeScript 5+.
 
@@ -41,89 +61,119 @@ npm install @kaneshir/lisa-mcp @google/generative-ai
 LISA_LLM_PROVIDER=gemini GEMINI_API_KEY=... npx fab orchestrate
 ```
 
-Without `@kaneshir/lisa-mcp`, your `BrowserAdapter` supplies its own selectors
-and flow generation is fully manual — this is supported and is the default.
-See [docs/lisa-mcp.md](./lisa-mcp.md) for the full integration guide.
+`fab doctor` will tell you exactly which optional peers are required for your
+config and which are merely recommended.
 
 ---
 
-## 2. Implement the adapters
+## 2. Customize the generated stubs
 
-Create a file (e.g. `fabric/adapters.ts`) and implement the eight interfaces.
-Start with stubs — the framework will call them in order and surface errors
-clearly.
+Each generated adapter has TODO methods that throw with the method name:
 
 ```typescript
-import {
-  AppAdapter, SimulationAdapter, ScoringAdapter, FeedbackAdapter,
-  BrowserAdapter, MemoryAdapter, Reporter, ScenarioPlanner,
-} from 'synthetic-test-fabric';
-
+// src/adapters/MyAppAdapter.ts (generated)
 export class MyAppAdapter implements AppAdapter {
-  async seed(iterRoot, config) { /* write mini-sim-export.json + lisa.db */ }
-  async reset(iterRoot) {}
-  async validateEnvironment() { return { healthy: true, errors: [], warnings: [] }; }
-  async verify(iterRoot) { /* throw if aliases missing */ }
-  async importRun(iterRoot, dbUrl) {}
-}
+  async seed(_iterRoot, _config) {
+    throw new Error('TODO: implement MyAppAdapter.seed');
+  }
 
-// ... implement the rest
+  async verify(_iterRoot) {
+    throw new Error('TODO: implement MyAppAdapter.verify');
+  }
+
+  // No-op methods are fine as-is for v1:
+  async reset(_iterRoot) {}
+  async validateEnvironment() { return { healthy: true, errors: [], warnings: [] }; }
+  async importRun(_iterRoot, _dbUrl) {}
+}
 ```
 
-See `demo/adapters.ts` in this repo for a complete reference implementation
-with no external dependencies.
+Replace the `throw new Error('TODO: ...')` lines with real implementations. See
+the [adapter contract](./adapter-contract.md) for what each method must do, and
+[`demo/adapters.ts`](../demo/adapters.ts) for a complete reference impl with no
+external dependencies.
+
+While you iterate, run the validator to confirm your edits still satisfy the
+interface:
+
+```bash
+npx fab adapter validate src/adapters/MyAppAdapter.ts
+```
+
+The validator runs in milliseconds (no test loop) and reports any missing
+required methods with line numbers.
+
+To add another adapter (e.g. a Slack reporter):
+
+```bash
+npx fab adapter scaffold reporter --out src/adapters/MySlackReporter.ts --name MySlackReporter
+```
 
 ---
 
 ## 3. Write Playwright flows
 
-Create a `flows/` directory with Playwright specs. The framework executes them
-in the TEST step and writes results to `flow-results.json` in the run root.
-
-Your `BrowserAdapter.runSpecs()` is responsible for invoking Playwright and
-pointing it at the correct run root via environment variables.
-
----
-
-## 4. Wire the orchestrator
-
-```typescript
-import { FabricOrchestrator, makeLoopId } from 'synthetic-test-fabric';
-import { MyAppAdapter, /* ... */ } from './fabric/adapters';
-
-const orchestrator = new FabricOrchestrator({
-  app:        new MyAppAdapter(),
-  simulation: new MySimulationAdapter(),
-  scoring:    new MyScoringAdapter(),
-  feedback:   new MyFeedbackAdapter(),
-  memory:     new MyMemoryAdapter(),
-  browser:    new MyBrowserAdapter(),
-  reporters:  [new ConsoleReporter()],
-  planner:    new MyScenarioPlanner(),
-});
-
-await orchestrator.run({
-  loopId:     makeLoopId(),
-  iterations: 1,
-  ticks:      5,
-  liveLlm:    false,
-  seekers:    2,
-  employers:  1,
-  employees:  1,
-});
-```
+Create specs under `flows/`. Your `BrowserAdapter.runSpecs()` is responsible for
+invoking Playwright and pointing it at the correct run root via environment
+variables. The framework executes them in the TEST step and writes results to
+`flow-results.json` in the run root.
 
 ---
 
-## 5. Run it
+## 4. Run a smoke check
 
 ```bash
-npx tsx fabric/run.ts
+npx fab smoke --keep
 ```
 
-A successful first run produces:
+`fab smoke` runs `SEED → VERIFY → SMOKE FLOW` against your config. `--keep`
+preserves the run root so you can inspect it.
+
+A successful run prints:
 
 ```
+[fab smoke] Run root: /tmp/fab-smoke-1234
+[fab smoke] → SEED
+[fab smoke] → VERIFY
+[fab smoke] → SMOKE FLOW
+[fab smoke] 0/0 passed
+[fab smoke] Passed.
+```
+
+Then ask the framework what state you're in:
+
+```bash
+npx fab status
+```
+
+```
+[fab status] last command: smoke @ 2026-05-10T16:00:00Z
+  root: /tmp/fab-smoke-1234 (ephemeral_kept)
+  phase: TEST   score: (none)
+  next: fab inspect --root /tmp/fab-smoke-1234
+```
+
+`fab inspect` returns a structured summary — phase reached, score, flow results,
+recent behavior events, latest screenshot:
+
+```bash
+npx fab inspect --root /tmp/fab-smoke-1234
+```
+
+---
+
+## 5. Run the full loop
+
+When smoke passes, scale up to the full orchestrator:
+
+```bash
+npx fab orchestrate --iterations 3 --ticks 10
+```
+
+A successful run produces:
+
+```
+[orchestrate] Iterations: 3, Ticks/iter: 10
 [orchestrate] iter-001: → SEED
 [orchestrate] iter-001: → VERIFY
 [orchestrate] iter-001: → RUN
@@ -132,8 +182,53 @@ A successful first run produces:
 [orchestrate] iter-001: → TEST
 [orchestrate] iter-001: → SCORE
 [orchestrate] iter-001: → FEEDBACK
-[orchestrate] Loop complete.
+[orchestrate] iter-002: ...
+[orchestrate] Loop complete. Root: /tmp/fabric-loop/fabric-loop-1234
 ```
+
+---
+
+## 6. Wire CI
+
+Use `--json` everywhere in scripts. The envelope contract is documented in
+[cli-json-output.md](./cli-json-output.md):
+
+```bash
+# Run + threshold gate
+npx fab orchestrate --iterations 1 --json > /tmp/run.json
+npx fab check --root "$(jq -r '.runRoot' /tmp/run.json)" --threshold 8.0 --json
+# exit 0 → score met threshold
+# exit 1 + status="ok" + data.ok=false → tool worked, score below threshold
+# exit 1 + status="error" → tool itself broke (e.g., missing fabric-score.json)
+```
+
+**Caller contract**: read both the exit code AND the envelope fields.
+`status: "ok"` + `data.ok: false` is a normal domain failure with exit 1, not
+an infrastructure error.
+
+---
+
+## 7. (Optional) Drive STF with Claude Code
+
+Install `fab-mcp` in your Claude Code MCP config (`~/.claude/.mcp.json` or
+project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "fab": { "command": "fab-mcp" }
+  }
+}
+```
+
+Then ask Claude things like:
+
+- *"Add a reporter that posts to Slack"* → scaffolds + validates an adapter for you
+- *"Why is the score dropping?"* → inspects the last loop root and explains
+- *"Set up STF for this product"* → walks `init → doctor → smoke` end-to-end
+
+Full install + tool reference: [mcp-install.md](./mcp-install.md).
+Trigger phrases + workflows: [docs/claude-skills/skills/stf/SKILL.md](./claude-skills/skills/stf/SKILL.md).
 
 ---
 
@@ -151,6 +246,9 @@ A successful first run produces:
 | `Reporter` | `console.log` the score |
 | `ScenarioPlanner` | Return a hardcoded `scenarioName` |
 
+The generated stubs already implement the no-op methods — you only need to
+fill in the `throw new Error('TODO: ...')` ones.
+
 ---
 
 ## Reference docs
@@ -158,3 +256,5 @@ A successful first run produces:
 - [overview.md](./overview.md) — what the framework does and why
 - [adapter-contract.md](./adapter-contract.md) — full interface definitions
 - [run-root-contract.md](./run-root-contract.md) — artifact layout and env vars
+- [cli-json-output.md](./cli-json-output.md) — `--json` envelope contract for scripting
+- [mcp-install.md](./mcp-install.md) — drive STF from Claude Code via `fab-mcp`


### PR DESCRIPTION
## Summary

The v0.4.0 epic shipped major new capabilities (\`fab init\`, \`fab-mcp\`, \`fab doctor\`, \`fab status\`, \`fab inspect\`, scaffolders, validators, the \`--json\` envelope contract) but the README still walked users through manual adapter implementation. A new user (or LLM landing on the repo) got the pre-v0.4.0 onboarding path. This PR closes the gap.

No code changes — pure docs alignment.

## What changed

### \`README.md\` — major rewrite

- **Lead with \`fab init\`** in a new "Use it in your product in 1 minute" section. Replaces the old "Your first loop in 5 minutes" hand-coded walkthrough.
- **New "Drive it with Claude Code" section** above the fold with the \`fab-mcp\` install snippet + sample agent intents.
- **New "What's new in v0.4.0"** table with the full new command surface.
- Added \`cli-json-output.md\`, \`mcp-install.md\`, \`CLAUDE.md\` to the docs table.
- Clarified that \`fab-mcp\` (CLI agent install) is **separate** from \`@kaneshir/lisa-mcp\` (flow generation) — different roles, easy to confuse.

### \`docs/quickstart.md\` — rewrite around \`fab init\`

- Step 1 now: \`fab init\` + \`fab doctor\`
- Step 2: customize generated TODO methods + iterate with \`fab adapter validate\` (sub-second feedback loop)
- New post-smoke section: \`fab status\` + \`fab inspect\`
- New step 6: \`--json\` + caller contract for CI scripting
- New step 7: optional Claude Code install via \`fab-mcp\`
- Removed the "import FabricOrchestrator and call .run() in your own script" path — still supported but no longer the recommended onboarding flow

### \`docs/overview.md\` — add operating-surface section

- New "How you operate it" section: 3 peer surfaces (CLI / MCP / library) with sample imports
- Cross-linked \`fab adapter scaffold\` from the adapter table

### \`docs/adapter-contract.md\` — top callout

- "Don't write these from scratch — \`fab adapter scaffold\`" pointer at the top
- Cross-link to quickstart §2 for the validate-while-you-iterate loop

## Test plan

- [x] \`npm run check:boundary\` — pass (46 files)
- [x] \`npm run check:package-surface\` — pass
- [x] \`npm test\` — 524/524 pass (docs-accuracy integration test from #26 still passes since \`CLAUDE.md\` decision tree is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)