### PR TITLE
release: v0.4.0 — agent-friendly surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.4.0] — agent-friendly surface
+## [0.4.0] — 2026-05-10 — agent-friendly surface
 
 The CLI surface a Claude Code (or similar) agent can drive end-to-end.
 Ships both `fab` (CLI) and `fab-mcp` (native MCP server) so agents can

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Generic engine for autonomous synthetic test loops: simulation → browser flows → scoring → feedback",
   "keywords": [
     "testing",


### PR DESCRIPTION
Version bump + CHANGELOG date for v0.4.0. All epic content (#18–#27 + #39) is already on develop.

Pack: 207.7 kB / 738.8 kB unpacked / 133 files.

Once merged → tag commit as `v0.4.0` → `npm publish`.