### PR TITLE
feat: MCP discovery — schema-driven coverage + fuzzing + catalog pinning (#44)

### DIFF
--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -296,6 +296,23 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP discovery + coverage (#44)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `runMcpCoverage` | function | Discover a target's advertised tools and measure coverage by invoking each with a schema-generated valid input. Read-only by default; reports covered / uncovered / policy-skipped / unsupported-schema and a coverage ratio. |
+| `snapshotCatalog` | function | Pin the advertised tool set (names + input-schema hashes + optional catalog version). |
+| `diffCatalog` | function | Diff a pinned catalog against the current one — flags added / removed / changed / version drift. |
+| `generateInputs` | function | JSON-Schema input generator: a valid instance + boundary-invalid instances + a list of unsupported constructs. |
+| `McpCoverageResult` | type | Result of `runMcpCoverage`. |
+| `CoverageOptions` | type | Options for `runMcpCoverage` (`includeWrites`, `probeInvalid`, `log`). |
+| `CatalogSnapshot` | type | Pinned catalog shape from `snapshotCatalog`. |
+| `CatalogDiff` | type | Drift result from `diffCatalog`. |
+| `SchemaGenResult` | type | Result of `generateInputs` (`valid`, `invalid`, `unsupported`). |
+| `JsonSchema` | type | Loose JSON-Schema object shape consumed by `generateInputs`. |
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,4 +144,21 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp discovery + coverage (#44)', () => {
+    it.each([
+      'snapshotCatalog',
+      'diffCatalog',
+      'runMcpCoverage',
+      'generateInputs',
+      'CatalogSnapshot',
+      'CatalogDiff',
+      'McpCoverageResult',
+      'CoverageOptions',
+      'SchemaGenResult',
+      'JsonSchema',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ export type {
   CallToolOptions,
   JsonRpcEnvelope,
 } from './mcp-target/executor';
+export { snapshotCatalog, diffCatalog, runMcpCoverage } from './mcp-target/discovery';
+export type { CatalogSnapshot, CatalogDiff, McpCoverageResult, CoverageOptions } from './mcp-target/discovery';
+export { generateInputs } from './mcp-target/schema-gen';
+export type { SchemaGenResult, JsonSchema } from './mcp-target/schema-gen';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/mcp-target/discovery.test.ts
+++ b/src/mcp-target/discovery.test.ts
@@ -39,6 +39,14 @@ describe('catalog pinning (#44)', () => {
     const t = [{ name: 'a', inputSchema: { type: 'object' } }];
     expect(diffCatalog(snapshotCatalog(t, 'v1'), snapshotCatalog(t, 'v1')).drifted).toBe(false);
   });
+
+  it('flags an annotation change that alters coverage policy (destructiveHint)', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' }, annotations: { destructiveHint: false } }]);
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' }, annotations: { destructiveHint: true } }]);
+    const d = diffCatalog(pinned, current);
+    expect(d.changed).toEqual(['a']);
+    expect(d.drifted).toBe(true);
+  });
 });
 
 describe('runMcpCoverage (#44)', () => {

--- a/src/mcp-target/discovery.test.ts
+++ b/src/mcp-target/discovery.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import BetterSqlite3 from 'better-sqlite3';
+
+import { startFixture, FixtureHandle } from './fixture-server';
+import { McpExecutor } from './executor';
+import { snapshotCatalog, diffCatalog, runMcpCoverage } from './discovery';
+import { applyLisaDbMigrations } from '../schema';
+import { BehaviorEventRecorder } from '../recorder';
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-disc-'));
+  const dbPath = path.join(dir, 'lisa.db');
+  const db = new BetterSqlite3(dbPath);
+  applyLisaDbMigrations(db);
+  db.close();
+  return dbPath;
+}
+
+describe('catalog pinning (#44)', () => {
+  it('detects added / removed / version drift', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' } }, { name: 'b', inputSchema: { x: 1 } }], 'v1');
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' } }, { name: 'c', inputSchema: {} }], 'v2');
+    const d = diffCatalog(pinned, current);
+    expect(d.added).toEqual(['c']);
+    expect(d.removed).toEqual(['b']);
+    expect(d.versionChanged).toBe(true);
+    expect(d.drifted).toBe(true);
+  });
+
+  it('flags a changed input schema under the same tool name', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object', properties: { x: { type: 'string' } } } }]);
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object', properties: { x: { type: 'number' } } } }]);
+    expect(diffCatalog(pinned, current).changed).toEqual(['a']);
+  });
+
+  it('reports no drift for identical catalogs', () => {
+    const t = [{ name: 'a', inputSchema: { type: 'object' } }];
+    expect(diffCatalog(snapshotCatalog(t, 'v1'), snapshotCatalog(t, 'v1')).drifted).toBe(false);
+  });
+});
+
+describe('runMcpCoverage (#44)', () => {
+  let fx: FixtureHandle;
+  let dbPath: string;
+  beforeEach(async () => {
+    fx = await startFixture();
+    dbPath = tempDbPath();
+  });
+  afterEach(async () => {
+    BehaviorEventRecorder.reset();
+    await fx.close();
+  });
+
+  it('covers reads, skips writes by policy, reports uncovered + invalid rejection', async () => {
+    const e = new McpExecutor({ endpoint: fx.url, dbPath, simulationId: 's', agentId: 'a', token: 'valid-aal2' });
+    const logs: string[] = [];
+    const cov = await runMcpCoverage(e, { log: (m) => logs.push(m) });
+
+    expect(cov.toolsTotal).toBe(4);
+    expect(cov.skippedByPolicy).toEqual(['fixture.write.create']);
+    expect(cov.covered).toEqual(expect.arrayContaining(['fixture.read.item', 'fixture.read.restricted']));
+    expect(cov.uncovered.map((u) => u.name)).toContain('fixture.broken');
+    expect(cov.invalidRejected).toContain('fixture.read.item'); // mistyped id rejected -32602
+    expect(cov.coverageRatio).toBeCloseTo(2 / 3, 5); // 2 covered of 3 in-policy
+    expect(cov.protocolVersion).toBe('2025-03-26');
+    // skips/unsupported are logged, never silent
+    expect(logs.some((l) => l.includes('fixture.write.create'))).toBe(true);
+
+    e.flush();
+  });
+
+  it('a read-only token under-covers honestly (scope-gated tool not visible)', async () => {
+    const e = new McpExecutor({ endpoint: fx.url, dbPath, simulationId: 's', agentId: 'a', token: 'valid-readonly' });
+    const cov = await runMcpCoverage(e);
+    // valid-readonly sees only read-scoped non-AAL2 tools: read.item + broken
+    expect(cov.toolsTotal).toBe(2);
+    expect(cov.covered).toEqual(['fixture.read.item']);
+    expect(cov.uncovered.map((u) => u.name)).toEqual(['fixture.broken']);
+    expect(cov.skippedByPolicy).toEqual([]);
+    e.flush();
+  });
+});

--- a/src/mcp-target/discovery.ts
+++ b/src/mcp-target/discovery.ts
@@ -49,7 +49,17 @@ export function snapshotCatalog(tools: McpToolMeta[], catalogVersion?: string): 
   return {
     catalogVersion,
     tools: tools
-      .map((t) => ({ name: t.name, schemaHash: schemaHash(t.inputSchema) }))
+      // Fingerprint = input schema + coverage-relevant annotations, so a
+      // destructiveHint/readOnlyHint flip (which changes the coverage policy and
+      // denominator) is flagged as drift, not silently absorbed.
+      .map((t) => ({
+        name: t.name,
+        schemaHash: schemaHash({
+          inputSchema: t.inputSchema ?? {},
+          destructiveHint: t.annotations?.destructiveHint ?? false,
+          readOnlyHint: t.annotations?.readOnlyHint ?? false,
+        }),
+      }))
       .sort((a, b) => a.name.localeCompare(b.name)),
   };
 }

--- a/src/mcp-target/discovery.ts
+++ b/src/mcp-target/discovery.ts
@@ -1,0 +1,156 @@
+/**
+ * MCP discovery + coverage (#44) — builds on McpExecutor.listTools():
+ *
+ *  - **Catalog pinning**: snapshot the advertised tool set (names + input-schema
+ *    hashes + optional catalog version) so drift (added/removed/changed tools)
+ *    is flagged instead of silently changing the coverage number.
+ *  - **Coverage**: invoke each advertised tool with a schema-generated valid
+ *    input and report covered / uncovered / policy-skipped / unsupported-schema.
+ *    Read-only by default — write/destructive tools are skipped unless opted in.
+ *  - **Schema fuzzing hook**: boundary-invalid inputs (from schema-gen) are
+ *    available per tool for #46 probes.
+ */
+
+import * as crypto from 'crypto';
+import { McpExecutor, McpToolMeta } from './executor';
+import { generateInputs } from './schema-gen';
+import { BEHAVIOR_OUTCOMES, BehaviorOutcome } from '../outcomes';
+
+// ---------------------------------------------------------------------------
+// Catalog pinning
+// ---------------------------------------------------------------------------
+
+export interface CatalogSnapshot {
+  catalogVersion?: string;
+  tools: Array<{ name: string; schemaHash: string }>;
+}
+
+export interface CatalogDiff {
+  added: string[];
+  removed: string[];
+  changed: string[]; // same name, different input-schema hash
+  versionChanged: boolean;
+  drifted: boolean;
+}
+
+function schemaHash(schema: unknown): string {
+  // Stable hash of the input schema (key order normalized).
+  return crypto.createHash('sha256').update(stableStringify(schema ?? {})).digest('hex').slice(0, 16);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((value as any)[k])}`).join(',')}}`;
+}
+
+export function snapshotCatalog(tools: McpToolMeta[], catalogVersion?: string): CatalogSnapshot {
+  return {
+    catalogVersion,
+    tools: tools
+      .map((t) => ({ name: t.name, schemaHash: schemaHash(t.inputSchema) }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+export function diffCatalog(pinned: CatalogSnapshot, current: CatalogSnapshot): CatalogDiff {
+  const pinnedMap = new Map(pinned.tools.map((t) => [t.name, t.schemaHash]));
+  const currentMap = new Map(current.tools.map((t) => [t.name, t.schemaHash]));
+
+  const added = current.tools.filter((t) => !pinnedMap.has(t.name)).map((t) => t.name);
+  const removed = pinned.tools.filter((t) => !currentMap.has(t.name)).map((t) => t.name);
+  const changed = current.tools
+    .filter((t) => pinnedMap.has(t.name) && pinnedMap.get(t.name) !== t.schemaHash)
+    .map((t) => t.name);
+  const versionChanged = (pinned.catalogVersion ?? null) !== (current.catalogVersion ?? null);
+
+  return {
+    added,
+    removed,
+    changed,
+    versionChanged,
+    drifted: added.length > 0 || removed.length > 0 || changed.length > 0 || versionChanged,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Coverage
+// ---------------------------------------------------------------------------
+
+export interface McpCoverageResult {
+  toolsTotal: number;
+  /** Tools invoked with a valid input that returned success. */
+  covered: string[];
+  /** Tools invoked but not successful (with the classified outcome). */
+  uncovered: Array<{ name: string; outcome: BehaviorOutcome }>;
+  /** Write/destructive tools skipped because writes weren't opted in. */
+  skippedByPolicy: string[];
+  /** Tools whose input schema used constructs the generator can't model. */
+  unsupportedSchemas: Array<{ name: string; constructs: string[] }>;
+  /** Tools that correctly rejected a boundary-invalid input. */
+  invalidRejected: string[];
+  /** Coverage ratio over the in-policy tool set (excludes skippedByPolicy). */
+  coverageRatio: number;
+  /** Protocol version exercised, for the artifact (#47/#1394). */
+  protocolVersion?: string;
+}
+
+export interface CoverageOptions {
+  /** Exercise write/destructive tools too (requires the executor's allowWrites). Default false. */
+  includeWrites?: boolean;
+  /** Also send one boundary-invalid input per tool and record correct rejections. Default true. */
+  probeInvalid?: boolean;
+  /** Sink for skip/unsupported notices so truncation is never silent. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Discover the target's advertised tools and measure coverage by invoking each
+ * with a schema-generated valid input. Read-only by default.
+ */
+export async function runMcpCoverage(executor: McpExecutor, opts: CoverageOptions = {}): Promise<McpCoverageResult> {
+  const log = opts.log ?? (() => undefined);
+  const probeInvalid = opts.probeInvalid ?? true;
+  const tools = await executor.listTools();
+
+  const result: McpCoverageResult = {
+    toolsTotal: tools.length,
+    covered: [],
+    uncovered: [],
+    skippedByPolicy: [],
+    unsupportedSchemas: [],
+    invalidRejected: [],
+    coverageRatio: 0,
+    protocolVersion: executor.negotiatedProtocolVersion,
+  };
+
+  for (const tool of tools) {
+    const isWrite = tool.annotations?.destructiveHint === true;
+    if (isWrite && !opts.includeWrites) {
+      result.skippedByPolicy.push(tool.name);
+      log(`skipped (write, read-only policy): ${tool.name}`);
+      continue;
+    }
+
+    const gen = generateInputs(tool.inputSchema);
+    if (gen.unsupported.length) {
+      result.unsupportedSchemas.push({ name: tool.name, constructs: gen.unsupported });
+      log(`unsupported schema constructs for ${tool.name}: ${gen.unsupported.join(', ')}`);
+    }
+
+    const r = await executor.callTool(tool.name, gen.valid as Record<string, unknown>, { write: isWrite });
+    if (r.ok) result.covered.push(tool.name);
+    else result.uncovered.push({ name: tool.name, outcome: r.outcome });
+
+    if (probeInvalid && gen.invalid.length) {
+      const inv = await executor.callTool(tool.name, gen.invalid[0].input as Record<string, unknown>, { write: isWrite });
+      // A schema-invalid input should be rejected (not a success).
+      if (!inv.ok && inv.outcome === BEHAVIOR_OUTCOMES.ERROR_400) result.invalidRejected.push(tool.name);
+    }
+  }
+
+  const inPolicy = result.toolsTotal - result.skippedByPolicy.length;
+  result.coverageRatio = inPolicy > 0 ? result.covered.length / inPolicy : 0;
+  return result;
+}

--- a/src/mcp-target/schema-gen.test.ts
+++ b/src/mcp-target/schema-gen.test.ts
@@ -52,6 +52,30 @@ describe('generateInputs (#44 schema consumer)', () => {
     expect(r.unsupported.some((u) => u.startsWith('$ref:'))).toBe(true);
   });
 
+  it('merges allOf object members into one valid input (all must hold)', () => {
+    const s = {
+      allOf: [
+        { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+        { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+      ],
+    };
+    const r = generateInputs(s);
+    expect(r.valid).toEqual({ a: 'x', b: 0 });
+    expect(r.unsupported).toEqual([]);
+    expect(r.invalid.some((i) => i.reason.startsWith('missing required field'))).toBe(true);
+  });
+
+  it('reports a non-object allOf member as unsupported', () => {
+    const r = generateInputs({ allOf: [{ type: 'object', properties: { a: { type: 'string' } } }, { type: 'string' }] });
+    expect(r.unsupported).toContain('allOf:non-object-member');
+  });
+
+  it('generates a const-violating invalid input', () => {
+    const r = generateInputs({ const: 'fixed' });
+    expect(r.valid).toBe('fixed');
+    expect(r.invalid.some((i) => i.reason === 'value !== const')).toBe(true);
+  });
+
   it('respects minItems and minLength', () => {
     const r = generateInputs({ type: 'array', items: { type: 'string' }, minItems: 2 });
     expect(r.valid).toEqual(['x', 'x']);

--- a/src/mcp-target/schema-gen.test.ts
+++ b/src/mcp-target/schema-gen.test.ts
@@ -1,0 +1,60 @@
+import { generateInputs } from './schema-gen';
+
+describe('generateInputs (#44 schema consumer)', () => {
+  it('object: valid has required fields; invalid drops one and mistypes another', () => {
+    const s = { type: 'object', properties: { a: { type: 'string' }, b: { type: 'number' } }, required: ['a', 'b'] };
+    const r = generateInputs(s);
+    expect(r.valid).toEqual({ a: 'x', b: 0 });
+    expect(r.invalid.some((i) => i.reason === 'missing required field: a')).toBe(true);
+    expect(r.invalid.some((i) => i.reason.startsWith('wrong type for field'))).toBe(true);
+  });
+
+  it('enum → valid is the first member; invalid includes a non-member', () => {
+    const r = generateInputs({ enum: ['red', 'green'] });
+    expect(r.valid).toBe('red');
+    expect(r.invalid.some((i) => i.reason === 'value not in enum')).toBe(true);
+  });
+
+  it('nested object + array of strings', () => {
+    const s = {
+      type: 'object',
+      properties: {
+        tags: { type: 'array', items: { type: 'string' } },
+        meta: { type: 'object', properties: { x: { type: 'boolean' } }, required: ['x'] },
+      },
+      required: ['tags', 'meta'],
+    };
+    expect(generateInputs(s).valid).toEqual({ tags: ['x'], meta: { x: true } });
+  });
+
+  it('resolves a local $ref (#/$defs)', () => {
+    const root = {
+      $defs: { Name: { type: 'string' } },
+      type: 'object',
+      properties: { n: { $ref: '#/$defs/Name' } },
+      required: ['n'],
+    };
+    expect(generateInputs(root).valid).toEqual({ n: 'x' });
+  });
+
+  it('anyOf picks the first branch; default is honored', () => {
+    expect(generateInputs({ anyOf: [{ type: 'string' }, { type: 'number' }] }).valid).toBe('x');
+    expect(generateInputs({ type: 'string', default: 'D' }).valid).toBe('D');
+  });
+
+  it('reports unsupported constructs explicitly', () => {
+    const r = generateInputs({ type: 'object', patternProperties: { '^x': { type: 'string' } }, if: {}, then: {} });
+    expect(r.unsupported).toEqual(expect.arrayContaining(['if', 'patternProperties', 'then']));
+  });
+
+  it('reports a non-local $ref as unsupported', () => {
+    const r = generateInputs({ $ref: 'https://example.com/schema' });
+    expect(r.unsupported.some((u) => u.startsWith('$ref:'))).toBe(true);
+  });
+
+  it('respects minItems and minLength', () => {
+    const r = generateInputs({ type: 'array', items: { type: 'string' }, minItems: 2 });
+    expect(r.valid).toEqual(['x', 'x']);
+    expect(generateInputs({ type: 'string', minLength: 3 }).valid).toBe('xxx');
+  });
+});

--- a/src/mcp-target/schema-gen.ts
+++ b/src/mcp-target/schema-gen.ts
@@ -73,17 +73,45 @@ function note(schema: JsonSchema, ctx: GenContext): void {
   }
 }
 
+/**
+ * Flatten `allOf` by merging member object schemas (properties + required) into
+ * the base — allOf means ALL members must hold, so the input must satisfy every
+ * one. Non-object members can't be merged and are reported as unsupported.
+ */
+function flattenAllOf(schema: JsonSchema, ctx: GenContext): JsonSchema {
+  if (!Array.isArray(schema.allOf) || !schema.allOf.length) return schema;
+  const merged: JsonSchema = { ...schema };
+  delete merged.allOf;
+  merged.type = merged.type ?? 'object';
+  const props: Record<string, JsonSchema> = { ...(merged.properties ?? {}) };
+  const required: string[] = Array.isArray(merged.required) ? [...merged.required] : [];
+  for (const memberIn of schema.allOf) {
+    const member = memberIn.$ref ? resolveRef(memberIn, ctx) : memberIn;
+    const sub = flattenAllOf(member, ctx); // support nested allOf
+    if (sub.type && sub.type !== 'object') {
+      ctx.unsupported.add('allOf:non-object-member');
+      continue;
+    }
+    Object.assign(props, sub.properties ?? {});
+    if (Array.isArray(sub.required)) required.push(...sub.required);
+  }
+  merged.properties = props;
+  merged.required = Array.from(new Set(required));
+  return merged;
+}
+
 function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
-  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const resolved = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const schema = flattenAllOf(resolved, ctx);
   note(schema, ctx);
 
   if ('default' in schema) return schema.default;
   if ('const' in schema) return schema.const;
   if (Array.isArray(schema.enum) && schema.enum.length) return schema.enum[0];
 
-  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+  for (const key of ['anyOf', 'oneOf'] as const) {
     if (Array.isArray(schema[key]) && schema[key].length) {
-      // Pick the first branch (allOf: first member — shallow, sufficient for inputs).
+      // anyOf/oneOf: any single branch satisfies — pick the first.
       return genValid(schema[key][0], ctx);
     }
   }
@@ -121,11 +149,18 @@ function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
 }
 
 function genInvalid(schemaIn: JsonSchema, ctx: GenContext): Array<{ input: unknown; reason: string }> {
-  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const resolved = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const schema = flattenAllOf(resolved, ctx);
   const out: Array<{ input: unknown; reason: string }> = [];
   const valid = genValid(schema, ctx);
 
   const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  // 0) const violation
+  if ('const' in schema) {
+    const v = schema.const;
+    out.push({ input: typeof v === 'number' ? v + 1 : '__not_const__', reason: 'value !== const' });
+  }
 
   // 1) drop a required field
   const required: string[] = Array.isArray(schema.required) ? schema.required : [];

--- a/src/mcp-target/schema-gen.ts
+++ b/src/mcp-target/schema-gen.ts
@@ -1,0 +1,172 @@
+/**
+ * JSON-Schema input generator (#44) — consumes an MCP tool's `inputSchema` and
+ * produces (a) a schema-valid instance to drive coverage and (b) boundary-invalid
+ * instances to drive schema-violation probes. Unsupported constructs are
+ * reported explicitly rather than silently skipped.
+ *
+ * This is a schema *consumer / input generator* — distinct from the zod→JSON-Schema
+ * *producer* in `src/mcp/server.ts`. Deterministic (no RNG) so runs are reproducible.
+ *
+ * Supported: type (string/number/integer/boolean/object/array/null), object
+ * properties + required, arrays + items, enum, const, default, anyOf/oneOf/allOf,
+ * local `$ref` (#/$defs, #/definitions), additionalProperties (object). Anything
+ * else (patternProperties, if/then/else, not, dependentSchemas, $ref to other
+ * documents, …) is recorded in `unsupported`.
+ */
+
+export type JsonSchema = Record<string, any>;
+
+export interface SchemaGenResult {
+  /** A schema-valid instance. */
+  valid: unknown;
+  /** Boundary-invalid instances, each with the reason it should be rejected. */
+  invalid: Array<{ input: unknown; reason: string }>;
+  /** Schema constructs encountered that this generator does not model. */
+  unsupported: string[];
+}
+
+const UNSUPPORTED_KEYWORDS = [
+  'patternProperties',
+  'if',
+  'then',
+  'else',
+  'not',
+  'dependentSchemas',
+  'dependencies',
+  'propertyNames',
+  'unevaluatedProperties',
+];
+
+/** Generate valid + boundary-invalid inputs for a schema. */
+export function generateInputs(schema: JsonSchema | undefined, root?: JsonSchema): SchemaGenResult {
+  const ctx: GenContext = { root: root ?? schema ?? {}, unsupported: new Set() };
+  const valid = genValid(schema ?? {}, ctx);
+  const invalid = genInvalid(schema ?? {}, ctx);
+  return { valid, invalid, unsupported: Array.from(ctx.unsupported).sort() };
+}
+
+interface GenContext {
+  root: JsonSchema;
+  unsupported: Set<string>;
+}
+
+function resolveRef(schema: JsonSchema, ctx: GenContext): JsonSchema {
+  const ref = schema.$ref;
+  if (typeof ref !== 'string') return schema;
+  // Only local refs of the form #/$defs/Name or #/definitions/Name.
+  const m = ref.match(/^#\/(\$defs|definitions)\/(.+)$/);
+  if (!m) {
+    ctx.unsupported.add(`$ref:${ref}`);
+    return {};
+  }
+  const target = (ctx.root[m[1]] ?? {})[m[2]];
+  if (!target) {
+    ctx.unsupported.add(`$ref:${ref}`);
+    return {};
+  }
+  return target;
+}
+
+function note(schema: JsonSchema, ctx: GenContext): void {
+  for (const kw of UNSUPPORTED_KEYWORDS) {
+    if (kw in schema) ctx.unsupported.add(kw);
+  }
+}
+
+function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
+  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  note(schema, ctx);
+
+  if ('default' in schema) return schema.default;
+  if ('const' in schema) return schema.const;
+  if (Array.isArray(schema.enum) && schema.enum.length) return schema.enum[0];
+
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    if (Array.isArray(schema[key]) && schema[key].length) {
+      // Pick the first branch (allOf: first member — shallow, sufficient for inputs).
+      return genValid(schema[key][0], ctx);
+    }
+  }
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case 'string': return typeof schema.minLength === 'number' ? 'x'.repeat(Math.max(1, schema.minLength)) : 'x';
+    case 'integer':
+    case 'number': return typeof schema.minimum === 'number' ? schema.minimum : 0;
+    case 'boolean': return true;
+    case 'null': return null;
+    case 'array': {
+      const items = schema.items ? genValid(schema.items, ctx) : 'x';
+      const min = typeof schema.minItems === 'number' ? schema.minItems : 1;
+      return Array.from({ length: Math.max(1, min) }, () => items);
+    }
+    case 'object':
+    default: {
+      const out: Record<string, unknown> = {};
+      const props = (schema.properties ?? {}) as Record<string, JsonSchema>;
+      const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+      // include all required props; for objects with no required, include all declared props
+      const keys = required.length ? required : Object.keys(props);
+      for (const k of keys) {
+        if (props[k]) out[k] = genValid(props[k], ctx);
+        else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+          out[k] = genValid(schema.additionalProperties, ctx);
+        } else {
+          out[k] = 'x';
+        }
+      }
+      return out;
+    }
+  }
+}
+
+function genInvalid(schemaIn: JsonSchema, ctx: GenContext): Array<{ input: unknown; reason: string }> {
+  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const out: Array<{ input: unknown; reason: string }> = [];
+  const valid = genValid(schema, ctx);
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  // 1) drop a required field
+  const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+  if (type === 'object' || schema.properties) {
+    if (required.length && valid && typeof valid === 'object') {
+      const missing = { ...(valid as Record<string, unknown>) };
+      delete missing[required[0]];
+      out.push({ input: missing, reason: `missing required field: ${required[0]}` });
+    }
+    // 2) wrong type for a declared property
+    const props = (schema.properties ?? {}) as Record<string, JsonSchema>;
+    const firstProp = Object.keys(props)[0];
+    if (firstProp && valid && typeof valid === 'object') {
+      const wrong = { ...(valid as Record<string, unknown>) };
+      wrong[firstProp] = wrongTypeFor(props[firstProp]);
+      out.push({ input: wrong, reason: `wrong type for field: ${firstProp}` });
+    }
+  }
+
+  // 3) enum violation
+  if (Array.isArray(schema.enum) && schema.enum.length) {
+    out.push({ input: '__not_in_enum__', reason: 'value not in enum' });
+  }
+
+  // 4) primitive type violation at the root
+  if (type && type !== 'object' && type !== 'array') {
+    out.push({ input: wrongTypeFor(schema), reason: `root expected ${type}` });
+  }
+
+  return out;
+}
+
+function wrongTypeFor(schema: JsonSchema): unknown {
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case 'string': return 12345; // number where string expected
+    case 'number':
+    case 'integer': return 'not-a-number';
+    case 'boolean': return 'not-a-bool';
+    case 'array': return 'not-an-array';
+    case 'object': return 'not-an-object';
+    default: return null;
+  }
+}


### PR DESCRIPTION
Closes #44. Stacked on #51 (#43 executor) — **base `feature/43-mcp-executor`**; merge order #50 → #51 → #52. Third Phase-A deliverable of epic #42.

## What
Schema-driven discovery + coverage built on `McpExecutor.listTools()`.

**`schema-gen.ts`** — a JSON-Schema **input generator** (consumer; distinct from the zod→JSON-Schema *producer* in `src/mcp/server.ts`). Deterministic. For any `inputSchema` it returns:
- a **valid** instance (drives coverage),
- **boundary-invalid** instances (drive schema-violation probes),
- an explicit **`unsupported`** list (never silently skips).
Handles object/required, arrays, `enum`, `const`, `default`, `anyOf`/`oneOf`/`allOf`, local `$ref` (`$defs`/`definitions`), `minItems`/`minLength`. Reports `patternProperties`/`if`-`then`-`else`/`not`/non-local-`$ref` as unsupported.

**`discovery.ts`**
- **Catalog pinning** — `snapshotCatalog` / `diffCatalog`: names + input-schema hashes + catalog version; flags **added / removed / changed / version drift** so coverage can't silently change.
- **`runMcpCoverage`** — invokes each advertised tool with a generated valid input; reports `covered` / `uncovered` / `skippedByPolicy` / `unsupportedSchemas` / `invalidRejected` + a `coverageRatio` over the in-policy set + the exercised `protocolVersion` (for #47/#1394). **Read-only by default** — write/destructive tools are skipped and **logged** (no silent truncation). One boundary-invalid probe per tool records a correct `-32602` rejection.

## Acceptance (ticket #44)
- ✅ Paginated discovery (via the executor; coverage target from the live catalog).
- ✅ Write/destructive skipped unless `includeWrites`; skips **logged** in the result.
- ✅ Schema-valid → success; schema-violating → expected error outcome.
- ✅ Unsupported constructs **reported**, not skipped.
- ✅ Catalog **drift** detected against the pinned snapshot.

## Tests
+21 (schema-gen 8, discovery/coverage 5, index-export guard). A read-only token **under-covers honestly** (scope-gated tool invisible → not counted) — explicit test. **Full suite 600 green, tsc strict, package-surface + boundary pass.**

## Next
#46 (generic protocol probe battery) consumes the boundary-invalid inputs + `expectedSecureOutcomes`; #47 folds `runMcpCoverage` output into `details.mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
