### PR TITLE
feat: re-land MCP executor + discovery onto main (#43, #44 — stranded by stacked merge)

### DIFF
--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -279,6 +279,23 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP target testing (#43)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `McpExecutor` | class | Streamable-HTTP MCP **target** client. Drives an MCP server as a system-under-test and records a BehaviorEvent per `tools/call`. Read-only by default (`allowWrites`). |
+| `McpError` | class | Thrown by `initialize`/`listTools` on a protocol failure. Has optional `.code`. |
+| `McpWriteBlockedError` | class | Thrown pre-network when a write/destructive tool is called without `allowWrites`. |
+| `classifyMcpOutcome` | function | Maps a JSON-RPC envelope (`error.code` / `result.isError`) to a `BehaviorOutcome` — classifies on the JSON-RPC layer (errors ride over HTTP 200), not HTTP status. |
+| `toolToScreen` | function | Stable `screen_path` for an MCP tool name (e.g. a `vendor.consumer.products.list` tool → `mcp_consumer_products_list`). |
+| `McpTargetConfig` | type | Constructor options for `McpExecutor` (endpoint, token/provider, protocol versions, `allowWrites`, timeout). |
+| `McpToolResult` | type | Result of a `callTool` — `ok`, `outcome`, `errorCode`, `isError`, raw JSON-RPC envelope, `httpStatus`. |
+| `McpToolMeta` | type | Discovered tool shape from `listTools` (name, schema, annotations). |
+| `CallToolOptions` | type | Per-call options (`write` force-override, `entityId`, `tick`). |
+| `JsonRpcEnvelope` | type | Raw JSON-RPC response envelope exposed on `McpToolResult.raw`. |
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -296,6 +296,23 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP discovery + coverage (#44)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `runMcpCoverage` | function | Discover a target's advertised tools and measure coverage by invoking each with a schema-generated valid input. Read-only by default; reports covered / uncovered / policy-skipped / unsupported-schema and a coverage ratio. |
+| `snapshotCatalog` | function | Pin the advertised tool set (names + input-schema hashes + optional catalog version). |
+| `diffCatalog` | function | Diff a pinned catalog against the current one — flags added / removed / changed / version drift. |
+| `generateInputs` | function | JSON-Schema input generator: a valid instance + boundary-invalid instances + a list of unsupported constructs. |
+| `McpCoverageResult` | type | Result of `runMcpCoverage`. |
+| `CoverageOptions` | type | Options for `runMcpCoverage` (`includeWrites`, `probeInvalid`, `log`). |
+| `CatalogSnapshot` | type | Pinned catalog shape from `snapshotCatalog`. |
+| `CatalogDiff` | type | Drift result from `diffCatalog`. |
+| `SchemaGenResult` | type | Result of `generateInputs` (`valid`, `invalid`, `unsupported`). |
+| `JsonSchema` | type | Loose JSON-Schema object shape consumed by `generateInputs`. |
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -127,4 +127,21 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp target testing (#43)', () => {
+    it.each([
+      'McpExecutor',
+      'McpError',
+      'McpWriteBlockedError',
+      'toolToScreen',
+      'classifyMcpOutcome',
+      'McpTargetConfig',
+      'McpToolResult',
+      'McpToolMeta',
+      'CallToolOptions',
+      'JsonRpcEnvelope',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,4 +144,21 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp discovery + coverage (#44)', () => {
+    it.each([
+      'snapshotCatalog',
+      'diffCatalog',
+      'runMcpCoverage',
+      'generateInputs',
+      'CatalogSnapshot',
+      'CatalogDiff',
+      'McpCoverageResult',
+      'CoverageOptions',
+      'SchemaGenResult',
+      'JsonSchema',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ export type {
   CallToolOptions,
   JsonRpcEnvelope,
 } from './mcp-target/executor';
+export { snapshotCatalog, diffCatalog, runMcpCoverage } from './mcp-target/discovery';
+export type { CatalogSnapshot, CatalogDiff, McpCoverageResult, CoverageOptions } from './mcp-target/discovery';
+export { generateInputs } from './mcp-target/schema-gen';
+export type { SchemaGenResult, JsonSchema } from './mcp-target/schema-gen';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,16 @@ export type { McpClientOptions, McpTool, McpCallResult } from './mcp-client';
 export { normalizeScreenPath } from './screen-path';
 export type { SyntheticConfig } from './config';
 export { loadSyntheticConfig } from './config';
-export { BEHAVIOR_OUTCOMES, classifyOutcome } from './outcomes';
+export { BEHAVIOR_OUTCOMES, classifyOutcome, classifyMcpOutcome } from './outcomes';
 export type { BehaviorOutcome } from './outcomes';
+export { McpExecutor, McpError, McpWriteBlockedError, toolToScreen } from './mcp-target/executor';
+export type {
+  McpTargetConfig,
+  McpToolResult,
+  McpToolMeta,
+  CallToolOptions,
+  JsonRpcEnvelope,
+} from './mcp-target/executor';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/mcp-target/discovery.test.ts
+++ b/src/mcp-target/discovery.test.ts
@@ -39,6 +39,14 @@ describe('catalog pinning (#44)', () => {
     const t = [{ name: 'a', inputSchema: { type: 'object' } }];
     expect(diffCatalog(snapshotCatalog(t, 'v1'), snapshotCatalog(t, 'v1')).drifted).toBe(false);
   });
+
+  it('flags an annotation change that alters coverage policy (destructiveHint)', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' }, annotations: { destructiveHint: false } }]);
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' }, annotations: { destructiveHint: true } }]);
+    const d = diffCatalog(pinned, current);
+    expect(d.changed).toEqual(['a']);
+    expect(d.drifted).toBe(true);
+  });
 });
 
 describe('runMcpCoverage (#44)', () => {

--- a/src/mcp-target/discovery.test.ts
+++ b/src/mcp-target/discovery.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import BetterSqlite3 from 'better-sqlite3';
+
+import { startFixture, FixtureHandle } from './fixture-server';
+import { McpExecutor } from './executor';
+import { snapshotCatalog, diffCatalog, runMcpCoverage } from './discovery';
+import { applyLisaDbMigrations } from '../schema';
+import { BehaviorEventRecorder } from '../recorder';
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-disc-'));
+  const dbPath = path.join(dir, 'lisa.db');
+  const db = new BetterSqlite3(dbPath);
+  applyLisaDbMigrations(db);
+  db.close();
+  return dbPath;
+}
+
+describe('catalog pinning (#44)', () => {
+  it('detects added / removed / version drift', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' } }, { name: 'b', inputSchema: { x: 1 } }], 'v1');
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object' } }, { name: 'c', inputSchema: {} }], 'v2');
+    const d = diffCatalog(pinned, current);
+    expect(d.added).toEqual(['c']);
+    expect(d.removed).toEqual(['b']);
+    expect(d.versionChanged).toBe(true);
+    expect(d.drifted).toBe(true);
+  });
+
+  it('flags a changed input schema under the same tool name', () => {
+    const pinned = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object', properties: { x: { type: 'string' } } } }]);
+    const current = snapshotCatalog([{ name: 'a', inputSchema: { type: 'object', properties: { x: { type: 'number' } } } }]);
+    expect(diffCatalog(pinned, current).changed).toEqual(['a']);
+  });
+
+  it('reports no drift for identical catalogs', () => {
+    const t = [{ name: 'a', inputSchema: { type: 'object' } }];
+    expect(diffCatalog(snapshotCatalog(t, 'v1'), snapshotCatalog(t, 'v1')).drifted).toBe(false);
+  });
+});
+
+describe('runMcpCoverage (#44)', () => {
+  let fx: FixtureHandle;
+  let dbPath: string;
+  beforeEach(async () => {
+    fx = await startFixture();
+    dbPath = tempDbPath();
+  });
+  afterEach(async () => {
+    BehaviorEventRecorder.reset();
+    await fx.close();
+  });
+
+  it('covers reads, skips writes by policy, reports uncovered + invalid rejection', async () => {
+    const e = new McpExecutor({ endpoint: fx.url, dbPath, simulationId: 's', agentId: 'a', token: 'valid-aal2' });
+    const logs: string[] = [];
+    const cov = await runMcpCoverage(e, { log: (m) => logs.push(m) });
+
+    expect(cov.toolsTotal).toBe(4);
+    expect(cov.skippedByPolicy).toEqual(['fixture.write.create']);
+    expect(cov.covered).toEqual(expect.arrayContaining(['fixture.read.item', 'fixture.read.restricted']));
+    expect(cov.uncovered.map((u) => u.name)).toContain('fixture.broken');
+    expect(cov.invalidRejected).toContain('fixture.read.item'); // mistyped id rejected -32602
+    expect(cov.coverageRatio).toBeCloseTo(2 / 3, 5); // 2 covered of 3 in-policy
+    expect(cov.protocolVersion).toBe('2025-03-26');
+    // skips/unsupported are logged, never silent
+    expect(logs.some((l) => l.includes('fixture.write.create'))).toBe(true);
+
+    e.flush();
+  });
+
+  it('a read-only token under-covers honestly (scope-gated tool not visible)', async () => {
+    const e = new McpExecutor({ endpoint: fx.url, dbPath, simulationId: 's', agentId: 'a', token: 'valid-readonly' });
+    const cov = await runMcpCoverage(e);
+    // valid-readonly sees only read-scoped non-AAL2 tools: read.item + broken
+    expect(cov.toolsTotal).toBe(2);
+    expect(cov.covered).toEqual(['fixture.read.item']);
+    expect(cov.uncovered.map((u) => u.name)).toEqual(['fixture.broken']);
+    expect(cov.skippedByPolicy).toEqual([]);
+    e.flush();
+  });
+});

--- a/src/mcp-target/discovery.ts
+++ b/src/mcp-target/discovery.ts
@@ -49,7 +49,17 @@ export function snapshotCatalog(tools: McpToolMeta[], catalogVersion?: string): 
   return {
     catalogVersion,
     tools: tools
-      .map((t) => ({ name: t.name, schemaHash: schemaHash(t.inputSchema) }))
+      // Fingerprint = input schema + coverage-relevant annotations, so a
+      // destructiveHint/readOnlyHint flip (which changes the coverage policy and
+      // denominator) is flagged as drift, not silently absorbed.
+      .map((t) => ({
+        name: t.name,
+        schemaHash: schemaHash({
+          inputSchema: t.inputSchema ?? {},
+          destructiveHint: t.annotations?.destructiveHint ?? false,
+          readOnlyHint: t.annotations?.readOnlyHint ?? false,
+        }),
+      }))
       .sort((a, b) => a.name.localeCompare(b.name)),
   };
 }

--- a/src/mcp-target/discovery.ts
+++ b/src/mcp-target/discovery.ts
@@ -1,0 +1,156 @@
+/**
+ * MCP discovery + coverage (#44) — builds on McpExecutor.listTools():
+ *
+ *  - **Catalog pinning**: snapshot the advertised tool set (names + input-schema
+ *    hashes + optional catalog version) so drift (added/removed/changed tools)
+ *    is flagged instead of silently changing the coverage number.
+ *  - **Coverage**: invoke each advertised tool with a schema-generated valid
+ *    input and report covered / uncovered / policy-skipped / unsupported-schema.
+ *    Read-only by default — write/destructive tools are skipped unless opted in.
+ *  - **Schema fuzzing hook**: boundary-invalid inputs (from schema-gen) are
+ *    available per tool for #46 probes.
+ */
+
+import * as crypto from 'crypto';
+import { McpExecutor, McpToolMeta } from './executor';
+import { generateInputs } from './schema-gen';
+import { BEHAVIOR_OUTCOMES, BehaviorOutcome } from '../outcomes';
+
+// ---------------------------------------------------------------------------
+// Catalog pinning
+// ---------------------------------------------------------------------------
+
+export interface CatalogSnapshot {
+  catalogVersion?: string;
+  tools: Array<{ name: string; schemaHash: string }>;
+}
+
+export interface CatalogDiff {
+  added: string[];
+  removed: string[];
+  changed: string[]; // same name, different input-schema hash
+  versionChanged: boolean;
+  drifted: boolean;
+}
+
+function schemaHash(schema: unknown): string {
+  // Stable hash of the input schema (key order normalized).
+  return crypto.createHash('sha256').update(stableStringify(schema ?? {})).digest('hex').slice(0, 16);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((value as any)[k])}`).join(',')}}`;
+}
+
+export function snapshotCatalog(tools: McpToolMeta[], catalogVersion?: string): CatalogSnapshot {
+  return {
+    catalogVersion,
+    tools: tools
+      .map((t) => ({ name: t.name, schemaHash: schemaHash(t.inputSchema) }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+export function diffCatalog(pinned: CatalogSnapshot, current: CatalogSnapshot): CatalogDiff {
+  const pinnedMap = new Map(pinned.tools.map((t) => [t.name, t.schemaHash]));
+  const currentMap = new Map(current.tools.map((t) => [t.name, t.schemaHash]));
+
+  const added = current.tools.filter((t) => !pinnedMap.has(t.name)).map((t) => t.name);
+  const removed = pinned.tools.filter((t) => !currentMap.has(t.name)).map((t) => t.name);
+  const changed = current.tools
+    .filter((t) => pinnedMap.has(t.name) && pinnedMap.get(t.name) !== t.schemaHash)
+    .map((t) => t.name);
+  const versionChanged = (pinned.catalogVersion ?? null) !== (current.catalogVersion ?? null);
+
+  return {
+    added,
+    removed,
+    changed,
+    versionChanged,
+    drifted: added.length > 0 || removed.length > 0 || changed.length > 0 || versionChanged,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Coverage
+// ---------------------------------------------------------------------------
+
+export interface McpCoverageResult {
+  toolsTotal: number;
+  /** Tools invoked with a valid input that returned success. */
+  covered: string[];
+  /** Tools invoked but not successful (with the classified outcome). */
+  uncovered: Array<{ name: string; outcome: BehaviorOutcome }>;
+  /** Write/destructive tools skipped because writes weren't opted in. */
+  skippedByPolicy: string[];
+  /** Tools whose input schema used constructs the generator can't model. */
+  unsupportedSchemas: Array<{ name: string; constructs: string[] }>;
+  /** Tools that correctly rejected a boundary-invalid input. */
+  invalidRejected: string[];
+  /** Coverage ratio over the in-policy tool set (excludes skippedByPolicy). */
+  coverageRatio: number;
+  /** Protocol version exercised, for the artifact (#47/#1394). */
+  protocolVersion?: string;
+}
+
+export interface CoverageOptions {
+  /** Exercise write/destructive tools too (requires the executor's allowWrites). Default false. */
+  includeWrites?: boolean;
+  /** Also send one boundary-invalid input per tool and record correct rejections. Default true. */
+  probeInvalid?: boolean;
+  /** Sink for skip/unsupported notices so truncation is never silent. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Discover the target's advertised tools and measure coverage by invoking each
+ * with a schema-generated valid input. Read-only by default.
+ */
+export async function runMcpCoverage(executor: McpExecutor, opts: CoverageOptions = {}): Promise<McpCoverageResult> {
+  const log = opts.log ?? (() => undefined);
+  const probeInvalid = opts.probeInvalid ?? true;
+  const tools = await executor.listTools();
+
+  const result: McpCoverageResult = {
+    toolsTotal: tools.length,
+    covered: [],
+    uncovered: [],
+    skippedByPolicy: [],
+    unsupportedSchemas: [],
+    invalidRejected: [],
+    coverageRatio: 0,
+    protocolVersion: executor.negotiatedProtocolVersion,
+  };
+
+  for (const tool of tools) {
+    const isWrite = tool.annotations?.destructiveHint === true;
+    if (isWrite && !opts.includeWrites) {
+      result.skippedByPolicy.push(tool.name);
+      log(`skipped (write, read-only policy): ${tool.name}`);
+      continue;
+    }
+
+    const gen = generateInputs(tool.inputSchema);
+    if (gen.unsupported.length) {
+      result.unsupportedSchemas.push({ name: tool.name, constructs: gen.unsupported });
+      log(`unsupported schema constructs for ${tool.name}: ${gen.unsupported.join(', ')}`);
+    }
+
+    const r = await executor.callTool(tool.name, gen.valid as Record<string, unknown>, { write: isWrite });
+    if (r.ok) result.covered.push(tool.name);
+    else result.uncovered.push({ name: tool.name, outcome: r.outcome });
+
+    if (probeInvalid && gen.invalid.length) {
+      const inv = await executor.callTool(tool.name, gen.invalid[0].input as Record<string, unknown>, { write: isWrite });
+      // A schema-invalid input should be rejected (not a success).
+      if (!inv.ok && inv.outcome === BEHAVIOR_OUTCOMES.ERROR_400) result.invalidRejected.push(tool.name);
+    }
+  }
+
+  const inPolicy = result.toolsTotal - result.skippedByPolicy.length;
+  result.coverageRatio = inPolicy > 0 ? result.covered.length / inPolicy : 0;
+  return result;
+}

--- a/src/mcp-target/executor.test.ts
+++ b/src/mcp-target/executor.test.ts
@@ -144,4 +144,60 @@ describe('McpExecutor (#43)', () => {
     expect(events[0].outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_403);
     expect(events[0].outcome_detail).toMatch(/^mcp_error_-32003:/);
   });
+
+  // ── read-only guard: fail closed BEFORE discovery (review P1) ───────────────
+  it('blocks a write tool called before discovery (visible: via destructiveHint)', async () => {
+    const e = exec('valid-aal2'); // can see the write tool, but allowWrites is off
+    await expect(e.callTool('fixture.write.create', { mode: 'preview', name: 'x' })).rejects.toBeInstanceOf(McpWriteBlockedError);
+    e.flush();
+    expect(readEvents(dbPath).length).toBe(0);
+  });
+
+  it('does not client-block a tool hidden from the session — server authz rejects it instead (no mutation)', async () => {
+    // A write tool the token can't even see is not client-blocked (probes must be
+    // able to attempt it); the server rejects it and nothing mutates.
+    const e = exec('valid-readonly');
+    const r = await e.callTool('fixture.write.create', { mode: 'preview', name: 'x' });
+    expect(r.ok).toBe(false);
+    expect(r.errorCode).toBe(-32003); // server scope/authz rejection
+    expect(fx.mutationCount()).toBe(0);
+  });
+
+  it('allows a read tool called before discovery (auto-resolves as read)', async () => {
+    const e = exec('valid-readonly'); // allowWrites off, no prior listTools
+    const r = await e.callTool('fixture.read.item', { id: 'x' });
+    expect(r.ok).toBe(true);
+  });
+
+  // ── stale-session recovery in listTools (review P2) ─────────────────────────
+  it('listTools recovers from a stale session by reinitializing', async () => {
+    const e = exec('valid-readonly');
+    await e.initialize();
+    fx.expireAllSessions();
+    const tools = await e.listTools(); // would throw without the shared reinit path
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  // ── protocol-version negotiation/fallback (review P2) ───────────────────────
+  it('negotiates a later configured protocol version when the preferred is unsupported', async () => {
+    const e = exec('valid-readonly', { protocolVersions: ['2099-01-01', '2025-03-26'] });
+    await e.initialize();
+    expect(e.negotiatedProtocolVersion).toBe('2025-03-26');
+  });
+
+  // ── previewThenCommit short-circuits on failed preview (review P2) ───────────
+  it('does not send commit when preview fails', async () => {
+    const f = await startFixture({ tokens: { wnormal: { scopes: ['write'], aal: 'normal', audience: 'mcp' } } });
+    try {
+      const e = new McpExecutor({ endpoint: f.url, dbPath, simulationId: 'sim-1', agentId: 'a', token: 'wnormal', allowWrites: true });
+      const { preview, commit } = await e.previewThenCommit('fixture.write.create', { name: 'widget' }, { idempotencyKey: 'k1' });
+      expect(preview.ok).toBe(false); // AAL2 step-up → preview rejected
+      expect(commit.outcome).toBe(BEHAVIOR_OUTCOMES.SKIPPED);
+      expect(f.mutationCount()).toBe(0);
+      e.flush();
+      expect(readEvents(dbPath).length).toBe(1); // only the preview event, no commit
+    } finally {
+      await f.close();
+    }
+  });
 });

--- a/src/mcp-target/executor.test.ts
+++ b/src/mcp-target/executor.test.ts
@@ -1,0 +1,147 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import BetterSqlite3 from 'better-sqlite3';
+
+import { startFixture, FixtureHandle } from './fixture-server';
+import { McpExecutor, McpWriteBlockedError, McpTargetConfig } from './executor';
+import { applyLisaDbMigrations } from '../schema';
+import { BehaviorEventRecorder } from '../recorder';
+import { BEHAVIOR_OUTCOMES } from '../outcomes';
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-exec-'));
+  const dbPath = path.join(dir, 'lisa.db');
+  const db = new BetterSqlite3(dbPath);
+  applyLisaDbMigrations(db);
+  db.close();
+  return dbPath;
+}
+
+function readEvents(dbPath: string): Array<{ execution_id: string; outcome: string; outcome_detail: string | null; action: string; entity_refs: string | null }> {
+  const db = new BetterSqlite3(dbPath, { readonly: true });
+  const rows = db.prepare('SELECT execution_id, outcome, outcome_detail, action, entity_refs FROM behavior_events ORDER BY recorded_at').all() as any[];
+  db.close();
+  return rows;
+}
+
+describe('McpExecutor (#43)', () => {
+  let fx: FixtureHandle;
+  let dbPath: string;
+
+  const exec = (token: string, extra: Partial<McpTargetConfig> = {}): McpExecutor =>
+    new McpExecutor({ endpoint: fx.url, dbPath, simulationId: 'sim-1', agentId: 'mcp-agent-1', token, ...extra });
+
+  beforeEach(async () => {
+    fx = await startFixture();
+    dbPath = tempDbPath();
+  });
+  afterEach(async () => {
+    BehaviorEventRecorder.reset();
+    await fx.close();
+  });
+
+  // ── lifecycle ──────────────────────────────────────────────────────────────
+  it('initialize negotiates the protocol version and captures session + capabilities', async () => {
+    const e = exec('valid-readonly');
+    await e.initialize();
+    expect(e.currentSessionId).toBeTruthy();
+    expect(e.negotiatedProtocolVersion).toBe('2025-03-26');
+    expect(e.capabilities).toBeDefined();
+  });
+
+  // ── discovery (pagination) ─────────────────────────────────────────────────
+  it('listTools follows nextCursor and returns the full visible catalog', async () => {
+    const small = await startFixture({ pageSize: 1, tokens: { all: { scopes: ['read', 'read:restricted', 'write'], aal: 'aal2', audience: 'mcp' } } });
+    const e = new McpExecutor({ endpoint: small.url, dbPath, simulationId: 'sim-1', agentId: 'a', token: 'all' });
+    try {
+      const tools = await e.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toEqual(expect.arrayContaining(['fixture.read.item', 'fixture.read.restricted', 'fixture.write.create', 'fixture.broken']));
+      expect(new Set(names).size).toBe(names.length);
+    } finally {
+      await small.close();
+    }
+  });
+
+  // ── reads + SSE parse ───────────────────────────────────────────────────────
+  it('callTool read succeeds and parses the SSE response form', async () => {
+    const e = exec('valid-readonly');
+    const r = await e.callTool('fixture.read.item', { id: 'x' });
+    expect(r.ok).toBe(true);
+    expect(r.outcome).toBe(BEHAVIOR_OUTCOMES.SUCCESS);
+    expect(r.raw.result.structuredContent.tool).toBe('fixture.read.item'); // proves the SSE body was parsed
+  });
+
+  // ── outcome classification on the JSON-RPC layer (over HTTP 200) ────────────
+  it('scope-gated rejection → ok:false, outcome error_403, errorCode -32003 (HTTP 200)', async () => {
+    const e = exec('valid-readonly');
+    const r = await e.callTool('fixture.read.restricted', {});
+    expect(r.httpStatus).toBe(200); // rejection rode over 200
+    expect(r.ok).toBe(false);
+    expect(r.errorCode).toBe(-32003);
+    expect(r.outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_403);
+  });
+
+  it('unknown tool → error_404; broken tool (-32000) → error_500', async () => {
+    const e = exec('valid-readonly');
+    const unknown = await e.callTool('nope.nope', {});
+    expect(unknown.outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_404);
+    const broken = await e.callTool('fixture.broken', {});
+    expect(broken.outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_500);
+  });
+
+  // ── read-only-by-default guardrail ──────────────────────────────────────────
+  it('write tool throws McpWriteBlockedError when allowWrites is off (no network call)', async () => {
+    const e = exec('valid-aal2'); // allowWrites defaults false
+    await expect(e.callTool('fixture.write.create', { mode: 'preview', name: 'x' }, { write: true })).rejects.toBeInstanceOf(McpWriteBlockedError);
+    // and inferred from discovered annotations (destructiveHint) after listTools
+    await e.listTools();
+    await expect(e.callTool('fixture.write.create', { mode: 'preview', name: 'x' })).rejects.toBeInstanceOf(McpWriteBlockedError);
+    // nothing was recorded
+    e.flush();
+    expect(readEvents(dbPath).length).toBe(0);
+  });
+
+  // ── two-phase write ─────────────────────────────────────────────────────────
+  it('previewThenCommit performs exactly one mutation', async () => {
+    const e = exec('valid-aal2', { allowWrites: true });
+    const { commit } = await e.previewThenCommit('fixture.write.create', { name: 'widget' }, { idempotencyKey: 'k1' });
+    expect(commit.ok).toBe(true);
+    expect(commit.raw.result.structuredContent.status).toBe('committed');
+    expect(fx.mutationCount()).toBe(1);
+  });
+
+  // ── stale session → reinitialize-and-retry ──────────────────────────────────
+  it('recovers from a stale session (404) by reinitializing and retrying once', async () => {
+    const e = exec('valid-readonly');
+    await e.initialize();
+    const firstSession = e.currentSessionId;
+    fx.expireAllSessions();
+    const r = await e.callTool('fixture.read.item', { id: 'x' });
+    expect(r.ok).toBe(true); // retry after reinit succeeded
+    expect(e.currentSessionId).not.toBe(firstSession);
+  });
+
+  // ── behavior-event recording ────────────────────────────────────────────────
+  it('records one behavior event per call with distinct execution_ids (two-call regression)', async () => {
+    const e = exec('valid-readonly');
+    await e.callTool('fixture.read.item', { id: 'a' });
+    await e.callTool('fixture.read.item', { id: 'b' });
+    e.flush();
+    const events = readEvents(dbPath);
+    expect(events.length).toBe(2);
+    expect(new Set(events.map((ev) => ev.execution_id)).size).toBe(2);
+    expect(events.every((ev) => JSON.parse(ev.entity_refs!).surface === 'mcp')).toBe(true);
+  });
+
+  it('preserves the raw mcp_error_<code> in the event detail', async () => {
+    const e = exec('valid-readonly');
+    await e.callTool('fixture.read.restricted', {}); // -32003
+    e.flush();
+    const events = readEvents(dbPath);
+    expect(events).toHaveLength(1);
+    expect(events[0].outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_403);
+    expect(events[0].outcome_detail).toMatch(/^mcp_error_-32003:/);
+  });
+});

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -1,0 +1,353 @@
+/**
+ * McpExecutor (#43) — a Streamable-HTTP MCP **target client** for STF target
+ * testing. The MCP analog of `src/api-executor.ts`: it drives an MCP server as
+ * a system-under-test and records a BehaviorEvent per tool call.
+ *
+ * This is a separate HTTP/Streamable path — it does NOT overload the stdio
+ * `src/mcp-client.ts` (which spawns the lisa-mcp binary for the inverse,
+ * agent-consuming-MCP use case).
+ *
+ * Faithful to the hard parts of a production contract (exercised by the #45
+ * fixture):
+ *   - `initialize` → `Mcp-Session-Id` lifecycle; protocol-version negotiation;
+ *     `MCP-Protocol-Version` header on subsequent requests
+ *   - both response forms parsed: plain JSON and request-scoped SSE
+ *   - stale-session (HTTP 404) → reinitialize-and-retry once
+ *   - paginated `tools/list` (follows `nextCursor`)
+ *   - outcomes classified on the JSON-RPC layer (errors ride over HTTP 200),
+ *     raw `mcp_error_<code>` preserved in the event detail
+ *   - read-only by default: write/destructive tools require `allowWrites`
+ *   - generic two-phase `previewThenCommit` (opaque confirmation-token passthrough)
+ */
+
+import { randomUUID } from 'crypto';
+import { BehaviorEventRecorder } from '../recorder';
+import { classifyMcpOutcome, BehaviorOutcome, BEHAVIOR_OUTCOMES } from '../outcomes';
+
+// ---------------------------------------------------------------------------
+// Public types (transport-agnostic surface)
+// ---------------------------------------------------------------------------
+
+export interface McpTargetConfig {
+  /** Full endpoint URL, e.g. http://host/mcp */
+  endpoint: string;
+  /** Path to lisa.db — behavior events are written here. */
+  dbPath: string;
+  simulationId: string;
+  agentId: string;
+  /** Static bearer token, or an async provider resolved on initialize. */
+  token?: string;
+  tokenProvider?: () => string | Promise<string>;
+  /** Extra headers attached to every request. */
+  headers?: Record<string, string>;
+  /** Protocol versions to negotiate; the first is preferred. Default ['2025-03-26']. */
+  protocolVersions?: string[];
+  /** Read-only by default — write/destructive tool calls throw unless this is true. */
+  allowWrites?: boolean;
+  /** Per-request timeout in ms. Default 30_000. */
+  timeoutMs?: number;
+}
+
+export interface McpToolMeta {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean; idempotentHint?: boolean };
+}
+
+export interface JsonRpcEnvelope<T = any> {
+  jsonrpc?: string;
+  id?: string | number | null;
+  result?: T;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface McpToolResult<T = any> {
+  /** True iff a JSON-RPC result is present and not flagged isError. */
+  ok: boolean;
+  outcome: BehaviorOutcome;
+  /** JSON-RPC error code, when the call was rejected at the protocol layer. */
+  errorCode?: number;
+  /** Tool-level isError flag (success envelope that nonetheless reports failure). */
+  isError: boolean;
+  /** Raw JSON-RPC envelope — not collapsed, so write-contract layers can read preview/token fields. */
+  raw: JsonRpcEnvelope<T>;
+  httpStatus: number;
+  durationMs: number;
+}
+
+export interface CallToolOptions {
+  /** Force write classification (otherwise inferred from discovered annotations). */
+  write?: boolean;
+  /** Override the behavior-event entity id. Defaults to agentId. */
+  entityId?: string;
+  /** Override the behavior-event tick. */
+  tick?: number;
+}
+
+export class McpError extends Error {
+  constructor(message: string, public readonly code?: number) {
+    super(message);
+    this.name = 'McpError';
+  }
+}
+
+/** Thrown by the read-only guardrail before any network call is made. */
+export class McpWriteBlockedError extends McpError {
+  constructor(toolName: string) {
+    super(`write tool "${toolName}" blocked: McpTargetConfig.allowWrites is not enabled`);
+    this.name = 'McpWriteBlockedError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Executor
+// ---------------------------------------------------------------------------
+
+export class McpExecutor {
+  private readonly cfg: Required<Pick<McpTargetConfig, 'endpoint' | 'dbPath' | 'simulationId' | 'agentId' | 'timeoutMs'>> &
+    McpTargetConfig;
+  private readonly preferredVersions: string[];
+
+  private rpcId = 1;
+  private _tick = 0;
+  private bearer?: string;
+  private sessionId?: string;
+  private _protocolVersion?: string;
+  private _capabilities?: Record<string, unknown>;
+  private catalog = new Map<string, McpToolMeta>();
+
+  constructor(config: McpTargetConfig) {
+    this.cfg = {
+      ...config,
+      endpoint: config.endpoint,
+      dbPath: config.dbPath,
+      simulationId: config.simulationId,
+      agentId: config.agentId,
+      timeoutMs: config.timeoutMs ?? 30_000,
+    };
+    this.preferredVersions = config.protocolVersions ?? ['2025-03-26'];
+  }
+
+  get negotiatedProtocolVersion(): string | undefined { return this._protocolVersion; }
+  get capabilities(): Record<string, unknown> | undefined { return this._capabilities; }
+  get currentSessionId(): string | undefined { return this.sessionId; }
+
+  setTick(tick: number): void { this._tick = tick; }
+
+  // ── lifecycle ────────────────────────────────────────────────────────────
+
+  /** Run the initialize handshake: negotiate version, capture session id + capabilities. */
+  async initialize(): Promise<void> {
+    if (!this.bearer) {
+      this.bearer = this.cfg.tokenProvider ? await this.cfg.tokenProvider() : this.cfg.token;
+    }
+    const preferred = this.preferredVersions[0];
+    const { envelope, sessionIdHeader, httpStatus } = await this.send('initialize', {
+      protocolVersion: preferred,
+      capabilities: {},
+      clientInfo: { name: 'stf-mcp-executor', version: '1.0.0' },
+    });
+    if (envelope.error) {
+      throw new McpError(`initialize failed: ${envelope.error.message}`, envelope.error.code);
+    }
+    if (httpStatus !== 200) {
+      throw new McpError(`initialize failed: HTTP ${httpStatus}`);
+    }
+    this.sessionId = sessionIdHeader ?? this.sessionId;
+    this._protocolVersion = (envelope.result?.protocolVersion as string) ?? preferred;
+    this._capabilities = (envelope.result?.capabilities as Record<string, unknown>) ?? {};
+    // best-effort initialized notification
+    await this.send('notifications/initialized', {}, { notification: true }).catch(() => undefined);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.sessionId) await this.initialize();
+  }
+
+  // ── discovery ──────────────────────────────────────────────────────────────
+
+  /** Paginated tools/list — follows nextCursor to completion so coverage can't false-green. */
+  async listTools(): Promise<McpToolMeta[]> {
+    await this.ensureInitialized();
+    const out: McpToolMeta[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 1000; guard++) {
+      const { envelope } = await this.send('tools/list', cursor ? { cursor } : {});
+      if (envelope.error) throw new McpError(`tools/list failed: ${envelope.error.message}`, envelope.error.code);
+      const page = (envelope.result?.tools as McpToolMeta[]) ?? [];
+      out.push(...page);
+      cursor = envelope.result?.nextCursor as string | undefined;
+      if (!cursor) break;
+    }
+    this.catalog = new Map(out.map((t) => [t.name, t]));
+    return out;
+  }
+
+  // ── tool calls ─────────────────────────────────────────────────────────────
+
+  /**
+   * Call a tool. Never throws on a JSON-RPC/network error — returns a classified
+   * McpToolResult so lanes and probes can inspect the outcome. Throws only the
+   * read-only guardrail (McpWriteBlockedError) before any network call.
+   */
+  async callTool<T = any>(name: string, args: Record<string, unknown> = {}, opts: CallToolOptions = {}): Promise<McpToolResult<T>> {
+    const isWrite = opts.write ?? this.catalog.get(name)?.annotations?.destructiveHint ?? false;
+    if (isWrite && !this.cfg.allowWrites) throw new McpWriteBlockedError(name);
+
+    await this.ensureInitialized();
+
+    let { envelope, httpStatus, durationMs } = await this.send('tools/call', { name, arguments: args });
+    // stale session → reinitialize once and retry
+    if (httpStatus === 404) {
+      this.sessionId = undefined;
+      await this.initialize();
+      ({ envelope, httpStatus, durationMs } = await this.send('tools/call', { name, arguments: args }));
+    }
+
+    const isError = envelope.result?.isError === true;
+    const outcome = classifyMcpOutcome(envelope);
+    const ok = !envelope.error && !isError && httpStatus < 400;
+    const detail = envelope.error
+      ? `mcp_error_${envelope.error.code}: ${envelope.error.message}`
+      : isError
+        ? 'mcp_result_isError'
+        : null;
+
+    this.record(`tools/call ${name}`, opts.entityId ?? this.cfg.agentId, opts.tick ?? this._tick, ok ? 'completed' : 'failed', outcome, detail, name);
+
+    return { ok, outcome, errorCode: envelope.error?.code, isError, raw: envelope, httpStatus, durationMs };
+  }
+
+  /**
+   * Generic two-phase write: preview → extract opaque confirmation token → commit.
+   * Product-specific token binding/idempotency lives downstream — this only
+   * passes the token through. Requires allowWrites.
+   */
+  async previewThenCommit<T = any>(
+    name: string,
+    args: Record<string, unknown>,
+    opts: { idempotencyKey?: string } = {},
+  ): Promise<{ preview: McpToolResult; commit: McpToolResult<T> }> {
+    const preview = await this.callTool(name, { ...args, mode: 'preview' }, { write: true });
+    const token =
+      (preview.raw.result?.structuredContent?.confirmationToken as string | undefined) ??
+      (preview.raw.result?.confirmationToken as string | undefined);
+    const commit = await this.callTool<T>(
+      name,
+      { ...args, mode: 'commit', confirmationToken: token, idempotencyKey: opts.idempotencyKey },
+      { write: true },
+    );
+    return { preview, commit };
+  }
+
+  /** Flush buffered behavior events to disk. */
+  flush(): void {
+    try {
+      BehaviorEventRecorder.getInstance(this.cfg.dbPath, 'simulation').flush();
+    } catch {
+      /* recorder may be uninitialized in stub scenarios — non-fatal */
+    }
+  }
+
+  // ── transport ──────────────────────────────────────────────────────────────
+
+  private async send(
+    method: string,
+    params: Record<string, unknown>,
+    opts: { notification?: boolean } = {},
+  ): Promise<{ envelope: JsonRpcEnvelope; sessionIdHeader?: string; httpStatus: number; durationMs: number }> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...this.cfg.headers,
+    };
+    if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`;
+    if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
+    if (this._protocolVersion) headers['MCP-Protocol-Version'] = this._protocolVersion;
+
+    const payload: Record<string, unknown> = { jsonrpc: '2.0', method, params };
+    if (!opts.notification) payload.id = this.rpcId++;
+
+    const start = Date.now();
+    try {
+      const res = await fetch(this.cfg.endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(this.cfg.timeoutMs),
+      });
+      const sessionIdHeader = res.headers.get('mcp-session-id') ?? undefined;
+      const envelope = await parseBody(res);
+      return { envelope, sessionIdHeader, httpStatus: res.status, durationMs: Date.now() - start };
+    } catch (err) {
+      // Network / timeout → synthesize an envelope so callers still get an outcome.
+      const aborted = (err as Error)?.name === 'TimeoutError' || (err as Error)?.name === 'AbortError';
+      return {
+        envelope: { error: { code: aborted ? -32000 : -32000, message: aborted ? 'request timed out' : `transport error: ${(err as Error)?.message}` } },
+        httpStatus: 0,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  private record(
+    action: string,
+    entityId: string,
+    tick: number,
+    execution_state: 'completed' | 'failed',
+    outcome: BehaviorOutcome,
+    outcome_detail: string | null,
+    toolName: string,
+  ): void {
+    try {
+      BehaviorEventRecorder.getInstance(this.cfg.dbPath, 'simulation').record({
+        execution_id: randomUUID(), // fresh per call → each call lands as its own event
+        simulation_id: this.cfg.simulationId,
+        agent_id: this.cfg.agentId,
+        entity_id: entityId,
+        persona_definition_id: null,
+        tick,
+        sim_time: new Date().toISOString(),
+        action,
+        reasoning: null,
+        event_source: 'agent',
+        event_kind: 'action',
+        execution_state,
+        outcome,
+        outcome_detail,
+        screen_path: toolToScreen(toolName),
+        entity_refs: JSON.stringify({ surface: 'mcp', toolName }),
+      });
+    } catch {
+      /* recording must never break the call flow */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse an MCP response body as either plain JSON or a request-scoped SSE stream. */
+async function parseBody(res: Response): Promise<JsonRpcEnvelope> {
+  if (res.status === 202) return {}; // accepted notification, no body
+  const ct = res.headers.get('content-type') ?? '';
+  const text = await res.text();
+  if (!text) return {};
+  if (ct.includes('text/event-stream') || text.startsWith('event:') || text.startsWith('data:')) {
+    const dataLine = text.split('\n').find((l) => l.startsWith('data:'));
+    return dataLine ? JSON.parse(dataLine.slice(dataLine.indexOf(':') + 1).trim()) : {};
+  }
+  return JSON.parse(text);
+}
+
+/** Stable screen_path for an MCP tool name: `redy.consumer.products.list` → `mcp_consumer_products_list`. */
+export function toolToScreen(toolName: string): string {
+  const parts = toolName.split('.');
+  const trimmed = parts.length > 1 ? parts.slice(1) : parts; // drop vendor prefix
+  return `mcp_${trimmed.join('_')}`.replace(/[^a-z0-9_]/gi, '_').toLowerCase();
+}
+
+// Re-export for convenience so adapters can assert outcomes without a second import.
+export { BEHAVIOR_OUTCOMES };

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -77,7 +77,13 @@ export interface McpToolResult<T = any> {
 }
 
 export interface CallToolOptions {
-  /** Force write classification (otherwise inferred from discovered annotations). */
+  /**
+   * Force write classification, bypassing the discovered-annotation inference:
+   * `true` = treat as write (gated by allowWrites), `false` = assert read-only.
+   * When omitted, write status is inferred from the tool's `destructiveHint`
+   * (auto-discovering the catalog if needed); unknown/hidden tools are left to
+   * server-side authz rather than client-blocked.
+   */
   write?: boolean;
   /** Override the behavior-event entity id. Defaults to agentId. */
   entityId?: string;
@@ -137,43 +143,91 @@ export class McpExecutor {
 
   // ── lifecycle ────────────────────────────────────────────────────────────
 
-  /** Run the initialize handshake: negotiate version, capture session id + capabilities. */
+  /**
+   * Run the initialize handshake. Negotiates by trying each configured protocol
+   * version in order (preferred first) until the server accepts one, so a
+   * single unsupported preferred version doesn't fail a target that supports a
+   * later configured one.
+   */
   async initialize(): Promise<void> {
     if (!this.bearer) {
       this.bearer = this.cfg.tokenProvider ? await this.cfg.tokenProvider() : this.cfg.token;
     }
-    const preferred = this.preferredVersions[0];
-    const { envelope, sessionIdHeader, httpStatus } = await this.send('initialize', {
-      protocolVersion: preferred,
-      capabilities: {},
-      clientInfo: { name: 'stf-mcp-executor', version: '1.0.0' },
-    });
-    if (envelope.error) {
-      throw new McpError(`initialize failed: ${envelope.error.message}`, envelope.error.code);
+    let lastError: { code?: number; message: string } | undefined;
+    for (const version of this.preferredVersions) {
+      const { envelope, sessionIdHeader, httpStatus } = await this.send('initialize', {
+        protocolVersion: version,
+        capabilities: {},
+        clientInfo: { name: 'stf-mcp-executor', version: '1.0.0' },
+      });
+      if (!envelope.error && httpStatus === 200) {
+        this.sessionId = sessionIdHeader ?? this.sessionId;
+        this._protocolVersion = (envelope.result?.protocolVersion as string) ?? version;
+        this._capabilities = (envelope.result?.capabilities as Record<string, unknown>) ?? {};
+        await this.send('notifications/initialized', {}, { notification: true }).catch(() => undefined);
+        return;
+      }
+      lastError = envelope.error ?? { message: `HTTP ${httpStatus}` };
     }
-    if (httpStatus !== 200) {
-      throw new McpError(`initialize failed: HTTP ${httpStatus}`);
-    }
-    this.sessionId = sessionIdHeader ?? this.sessionId;
-    this._protocolVersion = (envelope.result?.protocolVersion as string) ?? preferred;
-    this._capabilities = (envelope.result?.capabilities as Record<string, unknown>) ?? {};
-    // best-effort initialized notification
-    await this.send('notifications/initialized', {}, { notification: true }).catch(() => undefined);
+    throw new McpError(`initialize failed: ${lastError?.message ?? 'unknown'}`, lastError?.code);
   }
 
   private async ensureInitialized(): Promise<void> {
     if (!this.sessionId) await this.initialize();
   }
 
+  /**
+   * Send a session-scoped request, recovering from a stale session: an HTTP 404
+   * means the session expired, so reinitialize once and retry. Shared by both
+   * listTools() and callTool() so discovery and calls are equally resilient.
+   */
+  private async sessionRequest(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<{ envelope: JsonRpcEnvelope; httpStatus: number; durationMs: number }> {
+    await this.ensureInitialized();
+    let r = await this.send(method, params);
+    if (r.httpStatus === 404) {
+      this.sessionId = undefined;
+      await this.initialize();
+      r = await this.send(method, params);
+    }
+    return { envelope: r.envelope, httpStatus: r.httpStatus, durationMs: r.durationMs };
+  }
+
+  /**
+   * Resolve whether a tool is a write before any network call. Honors an
+   * explicit opts.write; otherwise infers from the discovered `destructiveHint`,
+   * auto-discovering the catalog once when writes are disabled so a *visible*
+   * destructive tool can't slip through before discovery (the key safety case).
+   *
+   * Unknown/hidden tools are NOT client-blocked: a tool hidden from the session
+   * can't actually mutate (the server rejects it), and adversarial probes must
+   * be able to attempt tools they shouldn't have access to. So the guard blocks
+   * only tools *known* to be destructive; hidden/unknown tools fall through to
+   * server-side authz enforcement.
+   */
+  private async resolveIsWrite(name: string, opts: CallToolOptions): Promise<boolean> {
+    if (opts.write !== undefined) return opts.write;
+    if (this.catalog.has(name)) return this.catalog.get(name)!.annotations?.destructiveHint ?? false;
+    if (this.cfg.allowWrites) return false; // writes permitted → no need to gate-discover
+    try {
+      await this.listTools();
+    } catch {
+      return false; // discovery failed → let the call proceed; server still enforces authz
+    }
+    const meta = this.catalog.get(name);
+    return meta ? meta.annotations?.destructiveHint ?? false : false; // hidden/unknown → server-enforced
+  }
+
   // ── discovery ──────────────────────────────────────────────────────────────
 
   /** Paginated tools/list — follows nextCursor to completion so coverage can't false-green. */
   async listTools(): Promise<McpToolMeta[]> {
-    await this.ensureInitialized();
     const out: McpToolMeta[] = [];
     let cursor: string | undefined;
     for (let guard = 0; guard < 1000; guard++) {
-      const { envelope } = await this.send('tools/list', cursor ? { cursor } : {});
+      const { envelope } = await this.sessionRequest('tools/list', cursor ? { cursor } : {});
       if (envelope.error) throw new McpError(`tools/list failed: ${envelope.error.message}`, envelope.error.code);
       const page = (envelope.result?.tools as McpToolMeta[]) ?? [];
       out.push(...page);
@@ -192,18 +246,11 @@ export class McpExecutor {
    * read-only guardrail (McpWriteBlockedError) before any network call.
    */
   async callTool<T = any>(name: string, args: Record<string, unknown> = {}, opts: CallToolOptions = {}): Promise<McpToolResult<T>> {
-    const isWrite = opts.write ?? this.catalog.get(name)?.annotations?.destructiveHint ?? false;
+    // Read-only guardrail runs pre-network and fails closed for unknown writes.
+    const isWrite = await this.resolveIsWrite(name, opts);
     if (isWrite && !this.cfg.allowWrites) throw new McpWriteBlockedError(name);
 
-    await this.ensureInitialized();
-
-    let { envelope, httpStatus, durationMs } = await this.send('tools/call', { name, arguments: args });
-    // stale session → reinitialize once and retry
-    if (httpStatus === 404) {
-      this.sessionId = undefined;
-      await this.initialize();
-      ({ envelope, httpStatus, durationMs } = await this.send('tools/call', { name, arguments: args }));
-    }
+    const { envelope, httpStatus, durationMs } = await this.sessionRequest('tools/call', { name, arguments: args });
 
     const isError = envelope.result?.isError === true;
     const outcome = classifyMcpOutcome(envelope);
@@ -233,6 +280,19 @@ export class McpExecutor {
     const token =
       (preview.raw.result?.structuredContent?.confirmationToken as string | undefined) ??
       (preview.raw.result?.confirmationToken as string | undefined);
+    // Fail fast: never send commit if preview failed or returned no token —
+    // a commit with an undefined token would create a spurious second event.
+    if (!preview.ok || !token) {
+      const commit: McpToolResult<T> = {
+        ok: false,
+        outcome: BEHAVIOR_OUTCOMES.SKIPPED,
+        isError: false,
+        raw: {},
+        httpStatus: 0,
+        durationMs: 0,
+      };
+      return { preview, commit };
+    }
     const commit = await this.callTool<T>(
       name,
       { ...args, mode: 'commit', confirmationToken: token, idempotencyKey: opts.idempotencyKey },

--- a/src/mcp-target/mcp-outcome.test.ts
+++ b/src/mcp-target/mcp-outcome.test.ts
@@ -1,0 +1,30 @@
+import { classifyMcpOutcome, BEHAVIOR_OUTCOMES } from '../outcomes';
+
+describe('classifyMcpOutcome (JSON-RPC layer, not HTTP status)', () => {
+  it('maps each JSON-RPC error code to the matching outcome', () => {
+    const cases: Array<[number, string]> = [
+      [-32001, BEHAVIOR_OUTCOMES.ERROR_401],
+      [-32003, BEHAVIOR_OUTCOMES.ERROR_403],
+      [-32004, BEHAVIOR_OUTCOMES.ERROR_404],
+      [-32601, BEHAVIOR_OUTCOMES.ERROR_404],
+      [-32029, BEHAVIOR_OUTCOMES.ERROR_429],
+      [-32602, BEHAVIOR_OUTCOMES.ERROR_400],
+      [-32600, BEHAVIOR_OUTCOMES.ERROR_400],
+      [-32700, BEHAVIOR_OUTCOMES.ERROR_400],
+      [-32000, BEHAVIOR_OUTCOMES.ERROR_500],
+      [-31999, BEHAVIOR_OUTCOMES.ERROR_UNKNOWN], // unmapped
+    ];
+    for (const [code, expected] of cases) {
+      expect(classifyMcpOutcome({ error: { code } })).toBe(expected);
+    }
+  });
+
+  it('treats a present result with no error as success', () => {
+    expect(classifyMcpOutcome({ result: { isError: false } })).toBe(BEHAVIOR_OUTCOMES.SUCCESS);
+    expect(classifyMcpOutcome({ result: {} })).toBe(BEHAVIOR_OUTCOMES.SUCCESS);
+  });
+
+  it('treats a result flagged isError as a tool-level failure', () => {
+    expect(classifyMcpOutcome({ result: { isError: true } })).toBe(BEHAVIOR_OUTCOMES.ERROR_UNKNOWN);
+  });
+});

--- a/src/mcp-target/schema-gen.test.ts
+++ b/src/mcp-target/schema-gen.test.ts
@@ -52,6 +52,30 @@ describe('generateInputs (#44 schema consumer)', () => {
     expect(r.unsupported.some((u) => u.startsWith('$ref:'))).toBe(true);
   });
 
+  it('merges allOf object members into one valid input (all must hold)', () => {
+    const s = {
+      allOf: [
+        { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+        { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+      ],
+    };
+    const r = generateInputs(s);
+    expect(r.valid).toEqual({ a: 'x', b: 0 });
+    expect(r.unsupported).toEqual([]);
+    expect(r.invalid.some((i) => i.reason.startsWith('missing required field'))).toBe(true);
+  });
+
+  it('reports a non-object allOf member as unsupported', () => {
+    const r = generateInputs({ allOf: [{ type: 'object', properties: { a: { type: 'string' } } }, { type: 'string' }] });
+    expect(r.unsupported).toContain('allOf:non-object-member');
+  });
+
+  it('generates a const-violating invalid input', () => {
+    const r = generateInputs({ const: 'fixed' });
+    expect(r.valid).toBe('fixed');
+    expect(r.invalid.some((i) => i.reason === 'value !== const')).toBe(true);
+  });
+
   it('respects minItems and minLength', () => {
     const r = generateInputs({ type: 'array', items: { type: 'string' }, minItems: 2 });
     expect(r.valid).toEqual(['x', 'x']);

--- a/src/mcp-target/schema-gen.test.ts
+++ b/src/mcp-target/schema-gen.test.ts
@@ -1,0 +1,60 @@
+import { generateInputs } from './schema-gen';
+
+describe('generateInputs (#44 schema consumer)', () => {
+  it('object: valid has required fields; invalid drops one and mistypes another', () => {
+    const s = { type: 'object', properties: { a: { type: 'string' }, b: { type: 'number' } }, required: ['a', 'b'] };
+    const r = generateInputs(s);
+    expect(r.valid).toEqual({ a: 'x', b: 0 });
+    expect(r.invalid.some((i) => i.reason === 'missing required field: a')).toBe(true);
+    expect(r.invalid.some((i) => i.reason.startsWith('wrong type for field'))).toBe(true);
+  });
+
+  it('enum → valid is the first member; invalid includes a non-member', () => {
+    const r = generateInputs({ enum: ['red', 'green'] });
+    expect(r.valid).toBe('red');
+    expect(r.invalid.some((i) => i.reason === 'value not in enum')).toBe(true);
+  });
+
+  it('nested object + array of strings', () => {
+    const s = {
+      type: 'object',
+      properties: {
+        tags: { type: 'array', items: { type: 'string' } },
+        meta: { type: 'object', properties: { x: { type: 'boolean' } }, required: ['x'] },
+      },
+      required: ['tags', 'meta'],
+    };
+    expect(generateInputs(s).valid).toEqual({ tags: ['x'], meta: { x: true } });
+  });
+
+  it('resolves a local $ref (#/$defs)', () => {
+    const root = {
+      $defs: { Name: { type: 'string' } },
+      type: 'object',
+      properties: { n: { $ref: '#/$defs/Name' } },
+      required: ['n'],
+    };
+    expect(generateInputs(root).valid).toEqual({ n: 'x' });
+  });
+
+  it('anyOf picks the first branch; default is honored', () => {
+    expect(generateInputs({ anyOf: [{ type: 'string' }, { type: 'number' }] }).valid).toBe('x');
+    expect(generateInputs({ type: 'string', default: 'D' }).valid).toBe('D');
+  });
+
+  it('reports unsupported constructs explicitly', () => {
+    const r = generateInputs({ type: 'object', patternProperties: { '^x': { type: 'string' } }, if: {}, then: {} });
+    expect(r.unsupported).toEqual(expect.arrayContaining(['if', 'patternProperties', 'then']));
+  });
+
+  it('reports a non-local $ref as unsupported', () => {
+    const r = generateInputs({ $ref: 'https://example.com/schema' });
+    expect(r.unsupported.some((u) => u.startsWith('$ref:'))).toBe(true);
+  });
+
+  it('respects minItems and minLength', () => {
+    const r = generateInputs({ type: 'array', items: { type: 'string' }, minItems: 2 });
+    expect(r.valid).toEqual(['x', 'x']);
+    expect(generateInputs({ type: 'string', minLength: 3 }).valid).toBe('xxx');
+  });
+});

--- a/src/mcp-target/schema-gen.ts
+++ b/src/mcp-target/schema-gen.ts
@@ -73,17 +73,45 @@ function note(schema: JsonSchema, ctx: GenContext): void {
   }
 }
 
+/**
+ * Flatten `allOf` by merging member object schemas (properties + required) into
+ * the base — allOf means ALL members must hold, so the input must satisfy every
+ * one. Non-object members can't be merged and are reported as unsupported.
+ */
+function flattenAllOf(schema: JsonSchema, ctx: GenContext): JsonSchema {
+  if (!Array.isArray(schema.allOf) || !schema.allOf.length) return schema;
+  const merged: JsonSchema = { ...schema };
+  delete merged.allOf;
+  merged.type = merged.type ?? 'object';
+  const props: Record<string, JsonSchema> = { ...(merged.properties ?? {}) };
+  const required: string[] = Array.isArray(merged.required) ? [...merged.required] : [];
+  for (const memberIn of schema.allOf) {
+    const member = memberIn.$ref ? resolveRef(memberIn, ctx) : memberIn;
+    const sub = flattenAllOf(member, ctx); // support nested allOf
+    if (sub.type && sub.type !== 'object') {
+      ctx.unsupported.add('allOf:non-object-member');
+      continue;
+    }
+    Object.assign(props, sub.properties ?? {});
+    if (Array.isArray(sub.required)) required.push(...sub.required);
+  }
+  merged.properties = props;
+  merged.required = Array.from(new Set(required));
+  return merged;
+}
+
 function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
-  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const resolved = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const schema = flattenAllOf(resolved, ctx);
   note(schema, ctx);
 
   if ('default' in schema) return schema.default;
   if ('const' in schema) return schema.const;
   if (Array.isArray(schema.enum) && schema.enum.length) return schema.enum[0];
 
-  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+  for (const key of ['anyOf', 'oneOf'] as const) {
     if (Array.isArray(schema[key]) && schema[key].length) {
-      // Pick the first branch (allOf: first member — shallow, sufficient for inputs).
+      // anyOf/oneOf: any single branch satisfies — pick the first.
       return genValid(schema[key][0], ctx);
     }
   }
@@ -121,11 +149,18 @@ function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
 }
 
 function genInvalid(schemaIn: JsonSchema, ctx: GenContext): Array<{ input: unknown; reason: string }> {
-  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const resolved = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const schema = flattenAllOf(resolved, ctx);
   const out: Array<{ input: unknown; reason: string }> = [];
   const valid = genValid(schema, ctx);
 
   const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  // 0) const violation
+  if ('const' in schema) {
+    const v = schema.const;
+    out.push({ input: typeof v === 'number' ? v + 1 : '__not_const__', reason: 'value !== const' });
+  }
 
   // 1) drop a required field
   const required: string[] = Array.isArray(schema.required) ? schema.required : [];

--- a/src/mcp-target/schema-gen.ts
+++ b/src/mcp-target/schema-gen.ts
@@ -1,0 +1,172 @@
+/**
+ * JSON-Schema input generator (#44) — consumes an MCP tool's `inputSchema` and
+ * produces (a) a schema-valid instance to drive coverage and (b) boundary-invalid
+ * instances to drive schema-violation probes. Unsupported constructs are
+ * reported explicitly rather than silently skipped.
+ *
+ * This is a schema *consumer / input generator* — distinct from the zod→JSON-Schema
+ * *producer* in `src/mcp/server.ts`. Deterministic (no RNG) so runs are reproducible.
+ *
+ * Supported: type (string/number/integer/boolean/object/array/null), object
+ * properties + required, arrays + items, enum, const, default, anyOf/oneOf/allOf,
+ * local `$ref` (#/$defs, #/definitions), additionalProperties (object). Anything
+ * else (patternProperties, if/then/else, not, dependentSchemas, $ref to other
+ * documents, …) is recorded in `unsupported`.
+ */
+
+export type JsonSchema = Record<string, any>;
+
+export interface SchemaGenResult {
+  /** A schema-valid instance. */
+  valid: unknown;
+  /** Boundary-invalid instances, each with the reason it should be rejected. */
+  invalid: Array<{ input: unknown; reason: string }>;
+  /** Schema constructs encountered that this generator does not model. */
+  unsupported: string[];
+}
+
+const UNSUPPORTED_KEYWORDS = [
+  'patternProperties',
+  'if',
+  'then',
+  'else',
+  'not',
+  'dependentSchemas',
+  'dependencies',
+  'propertyNames',
+  'unevaluatedProperties',
+];
+
+/** Generate valid + boundary-invalid inputs for a schema. */
+export function generateInputs(schema: JsonSchema | undefined, root?: JsonSchema): SchemaGenResult {
+  const ctx: GenContext = { root: root ?? schema ?? {}, unsupported: new Set() };
+  const valid = genValid(schema ?? {}, ctx);
+  const invalid = genInvalid(schema ?? {}, ctx);
+  return { valid, invalid, unsupported: Array.from(ctx.unsupported).sort() };
+}
+
+interface GenContext {
+  root: JsonSchema;
+  unsupported: Set<string>;
+}
+
+function resolveRef(schema: JsonSchema, ctx: GenContext): JsonSchema {
+  const ref = schema.$ref;
+  if (typeof ref !== 'string') return schema;
+  // Only local refs of the form #/$defs/Name or #/definitions/Name.
+  const m = ref.match(/^#\/(\$defs|definitions)\/(.+)$/);
+  if (!m) {
+    ctx.unsupported.add(`$ref:${ref}`);
+    return {};
+  }
+  const target = (ctx.root[m[1]] ?? {})[m[2]];
+  if (!target) {
+    ctx.unsupported.add(`$ref:${ref}`);
+    return {};
+  }
+  return target;
+}
+
+function note(schema: JsonSchema, ctx: GenContext): void {
+  for (const kw of UNSUPPORTED_KEYWORDS) {
+    if (kw in schema) ctx.unsupported.add(kw);
+  }
+}
+
+function genValid(schemaIn: JsonSchema, ctx: GenContext): unknown {
+  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  note(schema, ctx);
+
+  if ('default' in schema) return schema.default;
+  if ('const' in schema) return schema.const;
+  if (Array.isArray(schema.enum) && schema.enum.length) return schema.enum[0];
+
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    if (Array.isArray(schema[key]) && schema[key].length) {
+      // Pick the first branch (allOf: first member — shallow, sufficient for inputs).
+      return genValid(schema[key][0], ctx);
+    }
+  }
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case 'string': return typeof schema.minLength === 'number' ? 'x'.repeat(Math.max(1, schema.minLength)) : 'x';
+    case 'integer':
+    case 'number': return typeof schema.minimum === 'number' ? schema.minimum : 0;
+    case 'boolean': return true;
+    case 'null': return null;
+    case 'array': {
+      const items = schema.items ? genValid(schema.items, ctx) : 'x';
+      const min = typeof schema.minItems === 'number' ? schema.minItems : 1;
+      return Array.from({ length: Math.max(1, min) }, () => items);
+    }
+    case 'object':
+    default: {
+      const out: Record<string, unknown> = {};
+      const props = (schema.properties ?? {}) as Record<string, JsonSchema>;
+      const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+      // include all required props; for objects with no required, include all declared props
+      const keys = required.length ? required : Object.keys(props);
+      for (const k of keys) {
+        if (props[k]) out[k] = genValid(props[k], ctx);
+        else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+          out[k] = genValid(schema.additionalProperties, ctx);
+        } else {
+          out[k] = 'x';
+        }
+      }
+      return out;
+    }
+  }
+}
+
+function genInvalid(schemaIn: JsonSchema, ctx: GenContext): Array<{ input: unknown; reason: string }> {
+  const schema = schemaIn.$ref ? resolveRef(schemaIn, ctx) : schemaIn;
+  const out: Array<{ input: unknown; reason: string }> = [];
+  const valid = genValid(schema, ctx);
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  // 1) drop a required field
+  const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+  if (type === 'object' || schema.properties) {
+    if (required.length && valid && typeof valid === 'object') {
+      const missing = { ...(valid as Record<string, unknown>) };
+      delete missing[required[0]];
+      out.push({ input: missing, reason: `missing required field: ${required[0]}` });
+    }
+    // 2) wrong type for a declared property
+    const props = (schema.properties ?? {}) as Record<string, JsonSchema>;
+    const firstProp = Object.keys(props)[0];
+    if (firstProp && valid && typeof valid === 'object') {
+      const wrong = { ...(valid as Record<string, unknown>) };
+      wrong[firstProp] = wrongTypeFor(props[firstProp]);
+      out.push({ input: wrong, reason: `wrong type for field: ${firstProp}` });
+    }
+  }
+
+  // 3) enum violation
+  if (Array.isArray(schema.enum) && schema.enum.length) {
+    out.push({ input: '__not_in_enum__', reason: 'value not in enum' });
+  }
+
+  // 4) primitive type violation at the root
+  if (type && type !== 'object' && type !== 'array') {
+    out.push({ input: wrongTypeFor(schema), reason: `root expected ${type}` });
+  }
+
+  return out;
+}
+
+function wrongTypeFor(schema: JsonSchema): unknown {
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case 'string': return 12345; // number where string expected
+    case 'number':
+    case 'integer': return 'not-a-number';
+    case 'boolean': return 'not-a-bool';
+    case 'array': return 'not-an-array';
+    case 'object': return 'not-an-object';
+    default: return null;
+  }
+}

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -61,3 +61,38 @@ export function classifyOutcome(error: unknown): BehaviorOutcome {
 
   return BEHAVIOR_OUTCOMES.ERROR_UNKNOWN;
 }
+
+/**
+ * Classify an MCP JSON-RPC response envelope into a BehaviorOutcome.
+ *
+ * MCP carries tool rejections as a JSON-RPC `error` object (or a `result` with
+ * `isError: true`) — frequently **over HTTP 200**. Classifying on HTTP status
+ * would mis-bucket these, so target-testing must classify on the JSON-RPC layer.
+ * Codes mirror a production server's HTTP-status → JSON-RPC mapping
+ * (401→-32001, 403→-32003, 404→-32004, 429→-32029, 400→-32602).
+ *
+ * Maps onto the existing BEHAVIOR_OUTCOMES set — no schema migration required.
+ */
+export function classifyMcpOutcome(envelope: {
+  error?: { code?: number } | null;
+  result?: { isError?: boolean } | null;
+}): BehaviorOutcome {
+  const code = envelope.error?.code;
+  if (typeof code === 'number') {
+    switch (code) {
+      case -32001: return BEHAVIOR_OUTCOMES.ERROR_401; // unauthorized / audience / session-expired
+      case -32003: return BEHAVIOR_OUTCOMES.ERROR_403; // forbidden / scope / AAL step-up
+      case -32004: return BEHAVIOR_OUTCOMES.ERROR_404; // not found / unknown tool
+      case -32601: return BEHAVIOR_OUTCOMES.ERROR_404; // method not found
+      case -32029: return BEHAVIOR_OUTCOMES.ERROR_429; // rate limited
+      case -32602: return BEHAVIOR_OUTCOMES.ERROR_400; // invalid params (maps from HTTP 400)
+      case -32600: return BEHAVIOR_OUTCOMES.ERROR_400; // invalid request
+      case -32700: return BEHAVIOR_OUTCOMES.ERROR_400; // parse error
+      case -32000: return BEHAVIOR_OUTCOMES.ERROR_500; // server/internal error
+      default: return BEHAVIOR_OUTCOMES.ERROR_UNKNOWN;
+    }
+  }
+  // A `result` flagged isError is a tool-level failure with no protocol code.
+  if (envelope.result?.isError) return BEHAVIOR_OUTCOMES.ERROR_UNKNOWN;
+  return BEHAVIOR_OUTCOMES.SUCCESS;
+}


### PR DESCRIPTION
**Re-land of the stranded stack.** #51 (#43 executor) and #52 (#44 discovery) were merged into their stacked *base branches* (`feature/45`, `feature/43`) rather than `main`, so their 1,311 lines never reached `main` (classic stacked-PR merge race). `main` currently has only the #45 fixture.

This PR brings **#43 + #44 onto `main`** in one clean merge (merge-base `bf23cdc` = the already-merged #45 tip; diff is exactly executor + discovery, no fixture duplication).

## Contents (already reviewed + approved as #51 and #52)
- **#43** `McpExecutor` — Streamable-HTTP MCP target client + `classifyMcpOutcome` (JSON-RPC layer); session lifecycle, version negotiation, JSON+SSE, stale-404 reinit, read-only default, `previewThenCommit`, per-call BehaviorEvents. (Both review rounds actioned.)
- **#44** discovery — `schema-gen` (valid + boundary-invalid + unsupported reporting, allOf merge) and `discovery` (catalog pinning w/ annotation-aware drift, `runMcpCoverage`). (Review actioned.)
- Public exports + guard tests + `package-exports.md`.

## Verification
Full suite **604 green**, tsc strict, `check:package-surface` + `check:boundary` pass (local — CI will run now that the base is `main`).

Closes the gap from #51/#52. After merge I'll delete the stale `feature/43`/`feature/45` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
