### PR TITLE
feat: generic MCP protocol probe battery (#46)

### DIFF
--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -313,6 +313,22 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP protocol probes (#46)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `runProtocolProbes` | function | Run the generic, protocol-portable adversarial probe battery against any MCP target (unauthenticated, malformed JSON-RPC, parse error, unknown tool, schema-violating args, stale/missing session, unsupported protocol version). Classifies on the JSON-RPC layer; each probe declares its own expected-secure signal. Hard gate: any violation **or** inconclusive fails. |
+| `classifyVerdict` | function | Map `(isSecure, rejected)` → `secure` / `violation` / `inconclusive`. |
+| `ProbeBatteryResult` | type | Aggregate result (`results`, `secure`, `violations`, `inconclusive`, `passed`). |
+| `ProbeResult` | type | Per-probe result (`name`, `verdict`, `expectedSecure`, `outcome`). |
+| `ProbeOutcome` | type | Raw probe outcome (`rejected`, `errorCode`, `httpStatus`, `detail`). |
+| `ProbeVerdict` | type | `'secure' \| 'violation' \| 'inconclusive'`. |
+| `ProbeOptions` | type | Options (`log`). |
+
+> Product-specific authz probes (OAuth audience, AAL escalation, cross-org, confirmation-token forgery, idempotency abuse) are **out of scope here by design** — they live in the adopter layer.
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -161,4 +161,18 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp protocol probes (#46)', () => {
+    it.each([
+      'runProtocolProbes',
+      'classifyVerdict',
+      'ProbeVerdict',
+      'ProbeOutcome',
+      'ProbeResult',
+      'ProbeBatteryResult',
+      'ProbeOptions',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export { snapshotCatalog, diffCatalog, runMcpCoverage } from './mcp-target/disco
 export type { CatalogSnapshot, CatalogDiff, McpCoverageResult, CoverageOptions } from './mcp-target/discovery';
 export { generateInputs } from './mcp-target/schema-gen';
 export type { SchemaGenResult, JsonSchema } from './mcp-target/schema-gen';
+export { runProtocolProbes, classifyVerdict } from './mcp-target/probes';
+export type { ProbeVerdict, ProbeOutcome, ProbeResult, ProbeBatteryResult, ProbeOptions } from './mcp-target/probes';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/mcp-target/probes.test.ts
+++ b/src/mcp-target/probes.test.ts
@@ -39,6 +39,33 @@ describe('runProtocolProbes — compliant fixture', () => {
     expect(byName['unauthenticated']).toBe('secure');
     expect(byName['schema-violating-args']).toBe('secure');
     expect(byName['unsupported-protocol-version']).toBe('secure');
+    expect(res.schemaProbeSkipped).toBe(false);
+  });
+
+  it('resolves a rotating token provider exactly once (no false session mismatch)', async () => {
+    let calls = 0;
+    const tokenProvider = () => {
+      calls += 1;
+      return calls === 1 ? 'valid-aal2' : 'valid-readonly'; // a 2nd resolution would desync session vs probes
+    };
+    const res = await runProtocolProbes({ endpoint: fx.url, dbPath: '', simulationId: 's', agentId: 'a', tokenProvider });
+    expect(calls).toBe(1);
+    expect(res.passed).toBe(true);
+  });
+
+  it('emits inconclusive (not a silent skip) when no advertised tool has a fuzzable schema', async () => {
+    const f = await startFixture({
+      tools: [{ name: 'noargs.read', description: 'no-arg read', inputSchema: { type: 'object', properties: {} }, requiredScopes: ['read'], readOnlyHint: true }],
+      tokens: { t: { scopes: ['read'], aal: 'normal', audience: 'mcp' } },
+    });
+    try {
+      const res = await runProtocolProbes({ endpoint: f.url, dbPath: '', simulationId: 's', agentId: 'a', token: 't' });
+      expect(res.schemaProbeSkipped).toBe(true);
+      expect(res.results.find((r) => r.name === 'schema-violating-args')?.verdict).toBe('inconclusive');
+      expect(res.passed).toBe(false); // can't prove schema enforcement → gate not satisfied
+    } finally {
+      await f.close();
+    }
   });
 });
 

--- a/src/mcp-target/probes.test.ts
+++ b/src/mcp-target/probes.test.ts
@@ -1,0 +1,89 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+import { startFixture, FixtureHandle } from './fixture-server';
+import { runProtocolProbes, classifyVerdict } from './probes';
+
+describe('classifyVerdict — gate semantics', () => {
+  it('secure when the probe’s expected signal matched', () => {
+    expect(classifyVerdict(true, true)).toBe('secure');
+    expect(classifyVerdict(true, false)).toBe('secure');
+  });
+  it('violation when not secure and the request was NOT rejected (succeeded where rejection expected)', () => {
+    expect(classifyVerdict(false, false)).toBe('violation');
+  });
+  it('inconclusive when rejected but not in the expected way (crash/typo must not pass as secure)', () => {
+    expect(classifyVerdict(false, true)).toBe('inconclusive');
+  });
+});
+
+describe('runProtocolProbes — compliant fixture', () => {
+  let fx: FixtureHandle;
+  beforeEach(async () => {
+    fx = await startFixture();
+  });
+  afterEach(async () => {
+    await fx.close();
+  });
+
+  it('every generic probe holds; battery passes', async () => {
+    const res = await runProtocolProbes({ endpoint: fx.url, dbPath: '', simulationId: 's', agentId: 'a', token: 'valid-aal2' });
+    const byName = Object.fromEntries(res.results.map((r) => [r.name, r.verdict]));
+
+    expect(res.results.length).toBe(8);
+    expect(res.violations).toBe(0);
+    expect(res.inconclusive).toBe(0);
+    expect(res.passed).toBe(true);
+    // the key anti-regression: a stale-session 404 is SECURE for this probe, not "inconclusive"
+    expect(byName['stale-session']).toBe('secure');
+    expect(byName['unauthenticated']).toBe('secure');
+    expect(byName['schema-violating-args']).toBe('secure');
+    expect(byName['unsupported-protocol-version']).toBe('secure');
+  });
+});
+
+describe('runProtocolProbes — non-compliant server (ignores auth/session)', () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeAll((done) => {
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        let body: any = {};
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString());
+        } catch {
+          /* naive server ignores malformed input and still answers ok */
+        }
+        res.setHeader('Mcp-Session-Id', 'sess-1');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        if (body.method === 'initialize') {
+          return res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { protocolVersion: '2025-03-26', capabilities: {} } }));
+        }
+        if (body.method === 'tools/list') {
+          return res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { tools: [] } }));
+        }
+        return res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id ?? 1, result: { content: [], isError: false } }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+      done();
+    });
+  });
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  it('flags violations and fails the battery (server returns success where rejection was expected)', async () => {
+    const res = await runProtocolProbes({ endpoint: url, dbPath: '', simulationId: 's', agentId: 'a', token: 'whatever' });
+    const byName = Object.fromEntries(res.results.map((r) => [r.name, r.verdict]));
+
+    expect(res.violations).toBeGreaterThan(0);
+    expect(res.passed).toBe(false);
+    expect(byName['unauthenticated']).toBe('violation'); // accepted an unauthenticated call
+    expect(byName['stale-session']).toBe('violation'); // accepted a forged session (no 404)
+  });
+});

--- a/src/mcp-target/probes.ts
+++ b/src/mcp-target/probes.ts
@@ -44,6 +44,8 @@ export interface ProbeBatteryResult {
   secure: number;
   violations: number;
   inconclusive: number;
+  /** True if no advertised tool had a fuzzable schema, so schema enforcement couldn't be probed. */
+  schemaProbeSkipped: boolean;
   /** Hard gate: a violation OR an inconclusive fails the battery. */
   passed: boolean;
 }
@@ -183,26 +185,33 @@ export interface ProbeOptions {
  */
 export async function runProtocolProbes(config: McpTargetConfig, opts: ProbeOptions = {}): Promise<ProbeBatteryResult> {
   const log = opts.log ?? (() => undefined);
+  // Resolve the token ONCE and pass it explicitly, so a rotating/fresh provider
+  // can't initialize the session under a different token than the raw probes use
+  // (which would cause a false session/principal mismatch).
   const token = config.tokenProvider ? await config.tokenProvider() : config.token ?? '';
 
-  const exec = new McpExecutor(config);
+  const exec = new McpExecutor({ ...config, token, tokenProvider: undefined });
   await exec.initialize();
 
+  // Find the first non-destructive tool that has a fuzzable (boundary-invalid)
+  // schema. Scan ALL read tools, not just the first — a no-arg first tool must
+  // not disable the schema probe if a later tool is fuzzable.
   let readToolName: string | undefined;
   let invalidArgs: unknown;
   try {
     const tools = await exec.listTools();
-    const readTool = tools.find((t) => t.annotations?.destructiveHint !== true);
-    if (readTool) {
-      const gen = generateInputs(readTool.inputSchema);
+    for (const t of tools.filter((tool) => tool.annotations?.destructiveHint !== true)) {
+      const gen = generateInputs(t.inputSchema);
       if (gen.invalid.length) {
-        readToolName = readTool.name;
+        readToolName = t.name;
         invalidArgs = gen.invalid[0].input;
+        break;
       }
     }
   } catch {
     /* discovery failure just disables the schema-violation probe */
   }
+  const schemaProbeSkipped = readToolName === undefined;
 
   const ctx: ProbeContext = {
     endpoint: config.endpoint,
@@ -217,7 +226,16 @@ export async function runProtocolProbes(config: McpTargetConfig, opts: ProbeOpti
   const results: ProbeResult[] = [];
   for (const spec of PROBE_SPECS) {
     if (spec.requiresReadTool && (!ctx.readToolName || ctx.invalidArgs === undefined)) {
-      log(`skipped probe '${spec.name}': no read tool with a schema-invalid input available`);
+      // Don't silently drop — record inconclusive so the hard gate reflects that
+      // schema enforcement could not be verified (and #47 can read schemaProbeSkipped).
+      log(`probe '${spec.name}' → inconclusive (no advertised tool has a fuzzable schema)`);
+      results.push({
+        name: spec.name,
+        description: spec.description,
+        verdict: 'inconclusive',
+        expectedSecure: spec.expectedSecure,
+        outcome: { rejected: true, httpStatus: 0, detail: 'no advertised tool has a fuzzable schema' },
+      });
       continue;
     }
     const { headers: h, body } = spec.build(ctx);
@@ -230,7 +248,7 @@ export async function runProtocolProbes(config: McpTargetConfig, opts: ProbeOpti
   const secure = results.filter((r) => r.verdict === 'secure').length;
   const violations = results.filter((r) => r.verdict === 'violation').length;
   const inconclusive = results.filter((r) => r.verdict === 'inconclusive').length;
-  return { results, secure, violations, inconclusive, passed: violations === 0 && inconclusive === 0 };
+  return { results, secure, violations, inconclusive, schemaProbeSkipped, passed: violations === 0 && inconclusive === 0 };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp-target/probes.ts
+++ b/src/mcp-target/probes.ts
@@ -1,0 +1,279 @@
+/**
+ * Generic MCP protocol probe battery (#46) — portable adversarial probes that
+ * work against ANY compliant MCP server. The protocol surface is standardized
+ * even when application authz isn't, so these probes ship out of the box.
+ *
+ * This module is **protocol-portable only**. Product-specific authz probes
+ * (OAuth audience binding, AAL escalation, cross-org leakage, confirmation-token
+ * forgery, idempotency abuse) live downstream in the adopter (e.g. Redy #1393).
+ *
+ * Classification is on the **JSON-RPC layer** (rejections ride over HTTP 200),
+ * and each probe declares its own expected-secure signal — a stale-session 404,
+ * for example, is *secure* for the stale-session probe, not "inconclusive".
+ */
+
+import { randomUUID } from 'crypto';
+import { McpExecutor, McpTargetConfig } from './executor';
+import { generateInputs } from './schema-gen';
+
+// ---------------------------------------------------------------------------
+// Verdicts
+// ---------------------------------------------------------------------------
+
+export type ProbeVerdict = 'secure' | 'violation' | 'inconclusive';
+
+export interface ProbeOutcome {
+  /** True if the request was rejected (JSON-RPC error, result.isError, or HTTP >= 400). */
+  rejected: boolean;
+  /** JSON-RPC error code, when present. */
+  errorCode?: number;
+  httpStatus: number;
+  detail: string;
+}
+
+export interface ProbeResult {
+  name: string;
+  description: string;
+  verdict: ProbeVerdict;
+  expectedSecure: string;
+  outcome: ProbeOutcome;
+}
+
+export interface ProbeBatteryResult {
+  results: ProbeResult[];
+  secure: number;
+  violations: number;
+  inconclusive: number;
+  /** Hard gate: a violation OR an inconclusive fails the battery. */
+  passed: boolean;
+}
+
+/**
+ * Classify a probe. A boundary holds (`secure`) only if the probe's own
+ * expected-secure signal matched. Otherwise: a request that *succeeded* where
+ * rejection was expected is a `violation`; a request that was rejected but not
+ * in the expected way is `inconclusive` (a crash/typo must not pass as secure).
+ */
+export function classifyVerdict(isSecure: boolean, rejected: boolean): ProbeVerdict {
+  if (isSecure) return 'secure';
+  if (!rejected) return 'violation';
+  return 'inconclusive';
+}
+
+// ---------------------------------------------------------------------------
+// Probe specs
+// ---------------------------------------------------------------------------
+
+interface ProbeContext {
+  endpoint: string;
+  token: string;
+  sessionId: string;
+  protocolVersion: string;
+  readToolName?: string;
+  invalidArgs?: unknown;
+  timeoutMs: number;
+}
+
+interface ProbeSpec {
+  name: string;
+  description: string;
+  expectedSecure: string;
+  /** Needs a discovered read tool + a schema-invalid input. */
+  requiresReadTool?: boolean;
+  build(ctx: ProbeContext): { headers: Record<string, string>; body: string };
+  isSecure(o: ProbeOutcome): boolean;
+}
+
+function headers(
+  ctx: ProbeContext,
+  opts: { auth?: boolean; session?: string | null; version?: string } = {},
+): Record<string, string> {
+  const h: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (opts.auth !== false) h['Authorization'] = `Bearer ${ctx.token}`;
+  const session = opts.session === undefined ? ctx.sessionId : opts.session;
+  if (session) h['Mcp-Session-Id'] = session;
+  h['MCP-Protocol-Version'] = opts.version ?? ctx.protocolVersion;
+  return h;
+}
+
+const rpc = (method: string, params: Record<string, unknown> = {}): string =>
+  JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+
+const PROBE_SPECS: ProbeSpec[] = [
+  {
+    name: 'unauthenticated',
+    description: 'tools/list with no Authorization header',
+    expectedSecure: 'rejected with -32001 (or HTTP 401)',
+    build: (ctx) => ({ headers: headers(ctx, { auth: false, session: null }), body: rpc('tools/list') }),
+    isSecure: (o) => o.errorCode === -32001 || o.httpStatus === 401,
+  },
+  {
+    name: 'malformed-missing-jsonrpc',
+    description: 'request body without jsonrpc:"2.0"',
+    expectedSecure: 'rejected with -32600 (invalid request)',
+    build: (ctx) => ({ headers: headers(ctx), body: JSON.stringify({ id: 1, method: 'tools/list', params: {} }) }),
+    isSecure: (o) => o.errorCode === -32600,
+  },
+  {
+    name: 'malformed-parse-error',
+    description: 'syntactically invalid JSON body',
+    expectedSecure: 'rejected with -32700 (parse error)',
+    build: (ctx) => ({ headers: headers(ctx), body: '{ not valid json' }),
+    isSecure: (o) => o.errorCode === -32700,
+  },
+  {
+    name: 'unknown-tool',
+    description: 'tools/call for a non-existent tool',
+    expectedSecure: 'rejected with -32004 or -32601 (not found)',
+    build: (ctx) => ({ headers: headers(ctx), body: rpc('tools/call', { name: 'stf.__nonexistent__', arguments: {} }) }),
+    isSecure: (o) => o.errorCode === -32004 || o.errorCode === -32601,
+  },
+  {
+    name: 'schema-violating-args',
+    description: 'tools/call a known tool with schema-invalid arguments',
+    expectedSecure: 'rejected with -32602 (invalid params)',
+    requiresReadTool: true,
+    build: (ctx) => ({
+      headers: headers(ctx),
+      body: rpc('tools/call', { name: ctx.readToolName, arguments: ctx.invalidArgs as Record<string, unknown> }),
+    }),
+    isSecure: (o) => o.errorCode === -32602,
+  },
+  {
+    name: 'stale-session',
+    description: 'session-scoped call with a forged Mcp-Session-Id',
+    expectedSecure: 'rejected with HTTP 404 (client should reinitialize)',
+    build: (ctx) => ({ headers: headers(ctx, { session: `stale-${randomUUID()}` }), body: rpc('tools/list') }),
+    isSecure: (o) => o.httpStatus === 404,
+  },
+  {
+    name: 'missing-session',
+    description: 'session-scoped call with no Mcp-Session-Id',
+    expectedSecure: 'rejected with HTTP 404 or -32001',
+    build: (ctx) => ({ headers: headers(ctx, { session: null }), body: rpc('tools/list') }),
+    isSecure: (o) => o.httpStatus === 404 || o.errorCode === -32001,
+  },
+  {
+    name: 'unsupported-protocol-version',
+    description: 'initialize with an unsupported protocol version',
+    expectedSecure: 'rejected with -32602',
+    build: (ctx) => ({
+      headers: headers(ctx, { session: null, version: '1999-01-01' }),
+      body: rpc('initialize', { protocolVersion: '1999-01-01', capabilities: {}, clientInfo: { name: 'probe', version: '1' } }),
+    }),
+    isSecure: (o) => o.errorCode === -32602,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface ProbeOptions {
+  log?: (message: string) => void;
+}
+
+/**
+ * Run the generic protocol probe battery against an MCP target. Establishes a
+ * valid session for setup, then fires each probe with a raw request and
+ * classifies the result on the JSON-RPC layer.
+ */
+export async function runProtocolProbes(config: McpTargetConfig, opts: ProbeOptions = {}): Promise<ProbeBatteryResult> {
+  const log = opts.log ?? (() => undefined);
+  const token = config.tokenProvider ? await config.tokenProvider() : config.token ?? '';
+
+  const exec = new McpExecutor(config);
+  await exec.initialize();
+
+  let readToolName: string | undefined;
+  let invalidArgs: unknown;
+  try {
+    const tools = await exec.listTools();
+    const readTool = tools.find((t) => t.annotations?.destructiveHint !== true);
+    if (readTool) {
+      const gen = generateInputs(readTool.inputSchema);
+      if (gen.invalid.length) {
+        readToolName = readTool.name;
+        invalidArgs = gen.invalid[0].input;
+      }
+    }
+  } catch {
+    /* discovery failure just disables the schema-violation probe */
+  }
+
+  const ctx: ProbeContext = {
+    endpoint: config.endpoint,
+    token,
+    sessionId: exec.currentSessionId ?? '',
+    protocolVersion: exec.negotiatedProtocolVersion ?? '2025-03-26',
+    readToolName,
+    invalidArgs,
+    timeoutMs: config.timeoutMs ?? 30_000,
+  };
+
+  const results: ProbeResult[] = [];
+  for (const spec of PROBE_SPECS) {
+    if (spec.requiresReadTool && (!ctx.readToolName || ctx.invalidArgs === undefined)) {
+      log(`skipped probe '${spec.name}': no read tool with a schema-invalid input available`);
+      continue;
+    }
+    const { headers: h, body } = spec.build(ctx);
+    const outcome = await rawSend(ctx.endpoint, h, body, ctx.timeoutMs);
+    const verdict = classifyVerdict(spec.isSecure(outcome), outcome.rejected);
+    if (verdict !== 'secure') log(`probe '${spec.name}' → ${verdict} (expected: ${spec.expectedSecure}; got ${describe(outcome)})`);
+    results.push({ name: spec.name, description: spec.description, verdict, expectedSecure: spec.expectedSecure, outcome });
+  }
+
+  const secure = results.filter((r) => r.verdict === 'secure').length;
+  const violations = results.filter((r) => r.verdict === 'violation').length;
+  const inconclusive = results.filter((r) => r.verdict === 'inconclusive').length;
+  return { results, secure, violations, inconclusive, passed: violations === 0 && inconclusive === 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Raw transport
+// ---------------------------------------------------------------------------
+
+async function rawSend(endpoint: string, h: Record<string, string>, body: string, timeoutMs: number): Promise<ProbeOutcome> {
+  try {
+    const res = await fetch(endpoint, { method: 'POST', headers: h, body, signal: AbortSignal.timeout(timeoutMs) });
+    const envelope = await parseRpc(res);
+    const rejected = !!envelope.error || envelope.result?.isError === true || res.status >= 400;
+    return {
+      rejected,
+      errorCode: envelope.error?.code,
+      httpStatus: res.status,
+      detail: envelope.error?.message ?? '',
+    };
+  } catch (err) {
+    // Transport/timeout — rejected, but not a clean protocol signal → inconclusive territory.
+    return { rejected: true, httpStatus: 0, detail: `transport error: ${(err as Error)?.message}` };
+  }
+}
+
+async function parseRpc(res: Response): Promise<any> {
+  if (res.status === 202) return {};
+  const ct = res.headers.get('content-type') ?? '';
+  const text = await res.text();
+  if (!text) return {};
+  if (ct.includes('text/event-stream') || text.startsWith('event:') || text.startsWith('data:')) {
+    const line = text.split('\n').find((l) => l.startsWith('data:'));
+    try {
+      return line ? JSON.parse(line.slice(line.indexOf(':') + 1).trim()) : {};
+    } catch {
+      return {};
+    }
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+function describe(o: ProbeOutcome): string {
+  return `http=${o.httpStatus} code=${o.errorCode ?? 'none'} rejected=${o.rejected}`;
+}


### PR DESCRIPTION
Closes #46. Plain PR off `main` (no stacking, per the merge-race lesson). Fourth Phase-A deliverable of epic #42 — builds on the executor (#43) + schema-gen (#44) now on main.

## What
`runProtocolProbes(config)` — a generic, **protocol-portable** adversarial battery that works against any compliant MCP server out of the box:

| Probe | Expected-secure signal |
|---|---|
| unauthenticated | `-32001` / HTTP 401 |
| malformed: missing `jsonrpc` | `-32600` |
| malformed: parse error | `-32700` |
| unknown tool | `-32004` / `-32601` |
| schema-violating args (from schema-gen) | `-32602` |
| **stale session** (forged id) | **HTTP 404** |
| missing session | 404 / `-32001` |
| unsupported protocol version | `-32602` |

## Key design points (carry the prior review constraints)
- **Classifies on the JSON-RPC layer** — rejections ride over HTTP 200; never HTTP status alone.
- **Per-probe `expectedSecure`** — a stale-session **404 is *secure*** for that probe, not globally "inconclusive" (the bug the earlier review flagged).
- **`classifyVerdict` gate** — `secure` / `violation` (succeeded where rejection expected) / `inconclusive` (rejected the wrong way — a crash/typo must not pass). **Hard gate: any violation OR inconclusive fails.**
- **Protocol-portable ONLY** — product authz probes (audience, AAL, cross-org, token forgery, idempotency) are out of scope by design and live in the adopter (Redy #1393).

## Tests
+5: gate-semantics unit; **compliant fixture → all 8 secure, battery passes** (incl. stale-404-is-secure); **a deliberately non-compliant server → violations caught, battery fails**. Full suite **616 green**, tsc strict, package-surface + boundary pass.

## Remaining Phase A
#47 (scoring → `details.mcp`, consuming coverage + this battery) → #48 (docs + **v0.5.0 release**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
