### PR TITLE
ci: raise flaky tarball-install test timeout (90s→180s, shell 120s→240s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           mapfile -t tests < <(npx jest --listTests --runInBand)
           for test_file in "${tests[@]}"; do
             echo "::group::${test_file#$GITHUB_WORKSPACE/}"
-            timeout 120s npx jest --forceExit --runInBand --testTimeout=15000 --runTestsByPath "$test_file"
+            timeout 240s npx jest --forceExit --runInBand --testTimeout=15000 --runTestsByPath "$test_file"
             echo "::endgroup::"
           done
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -321,7 +321,10 @@ describe('Release readiness — npm pack + install + npx fab-mcp', () => {
       fs.rmSync(tarballDir, { recursive: true, force: true });
       fs.rmSync(consumerDir, { recursive: true, force: true });
     }
-  }, 90_000);
+    // npm pack + a fresh install that recompiles native deps (better-sqlite3)
+    // routinely takes ~90–100s on CI runners; 90s was too tight and tripped
+    // intermittently. Give real headroom (paired with the 240s CI shell cap).
+  }, 180_000);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The `src/integration.test.ts` release-readiness test (`npm pack` + fresh `npm install` recompiling better-sqlite3) routinely takes ~90–100s on CI runners — the 90s jest per-test timeout tripped intermittently (failed on #53 first run + both #54 runs, passed on #53 retry). Raises the jest per-test timeout 90s→180s and the per-file CI shell cap 120s→240s for real headroom. **No product code change.** Unblocks #54 (and the rest of Phase A) once merged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)