### PR TITLE
feat: MCP target scoring → details.mcp (#47)

### DIFF
--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -329,6 +329,17 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP target scoring (#47)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `assessMcpTarget` | function | End-to-end MCP target assessment: discovery coverage + protocol probe battery, returned as a `details.mcp`-shaped score (carries the exercised protocol version). Optional `coverageThreshold` and `surface` profile. |
+| `mcpScoreToDetails` | function | Wrap an `McpTargetScore` under the `mcp` key for merging into `FabricScore.details`. |
+| `McpTargetScore` | type | `{ surface?, protocolVersion?, coverage{…}, adversarial{…}, passed }`. |
+| `AssessMcpTargetOptions` | type | `{ surface?, includeWrites?, coverageThreshold?, log? }`. |
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -175,4 +175,15 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp target scoring (#47)', () => {
+    it.each([
+      'assessMcpTarget',
+      'mcpScoreToDetails',
+      'McpTargetScore',
+      'AssessMcpTargetOptions',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export { generateInputs } from './mcp-target/schema-gen';
 export type { SchemaGenResult, JsonSchema } from './mcp-target/schema-gen';
 export { runProtocolProbes, classifyVerdict } from './mcp-target/probes';
 export type { ProbeVerdict, ProbeOutcome, ProbeResult, ProbeBatteryResult, ProbeOptions } from './mcp-target/probes';
+export { assessMcpTarget, mcpScoreToDetails } from './mcp-target/score';
+export type { McpTargetScore, AssessMcpTargetOptions } from './mcp-target/score';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/mcp-target/score.test.ts
+++ b/src/mcp-target/score.test.ts
@@ -37,6 +37,15 @@ describe('assessMcpTarget (#47)', () => {
     expect(score.passed).toBe(false);
   });
 
+  it('includeWrites enables write coverage without throwing (forces executor allowWrites)', async () => {
+    // Caller sets only includeWrites — no config.allowWrites. Must return a score,
+    // not throw McpWriteBlockedError at the first destructive tool.
+    const score = await assessMcpTarget(cfg(), { includeWrites: true });
+    expect(score.coverage.skippedByPolicy).toBe(0); // writes no longer skipped by policy
+    expect(score.coverage.toolsTotal).toBe(4);
+    expect(score.adversarial.passed).toBe(true);
+  });
+
   it('mcpScoreToDetails wraps the score under the mcp key for FabricScore.details', async () => {
     const score = await assessMcpTarget(cfg());
     const details = mcpScoreToDetails(score);

--- a/src/mcp-target/score.test.ts
+++ b/src/mcp-target/score.test.ts
@@ -1,0 +1,49 @@
+import { startFixture, FixtureHandle } from './fixture-server';
+import { assessMcpTarget, mcpScoreToDetails } from './score';
+
+describe('assessMcpTarget (#47)', () => {
+  let fx: FixtureHandle;
+  beforeEach(async () => {
+    fx = await startFixture();
+  });
+  afterEach(async () => {
+    await fx.close();
+  });
+
+  const cfg = () => ({ endpoint: fx.url, dbPath: '', simulationId: 's', agentId: 'a', token: 'valid-aal2' });
+
+  it('combines coverage + probes into a details.mcp-shaped score', async () => {
+    const score = await assessMcpTarget(cfg(), { surface: 'read-only-surface' });
+
+    expect(score.surface).toBe('read-only-surface');
+    expect(score.protocolVersion).toBe('2025-03-26');
+    // coverage: read.item + read.restricted covered, broken uncovered, write skipped
+    expect(score.coverage.toolsTotal).toBe(4);
+    expect(score.coverage.covered).toBe(2);
+    expect(score.coverage.skippedByPolicy).toBe(1);
+    expect(score.coverage.ratio).toBeCloseTo(2 / 3, 5);
+    // adversarial: all 8 generic probes hold
+    expect(score.adversarial.violations).toBe(0);
+    expect(score.adversarial.inconclusive).toBe(0);
+    expect(score.adversarial.passed).toBe(true);
+    // overall passes (no coverage threshold)
+    expect(score.passed).toBe(true);
+  });
+
+  it('fails overall when the coverage threshold is not met (even if probes pass)', async () => {
+    const score = await assessMcpTarget(cfg(), { coverageThreshold: 0.8 });
+    expect(score.adversarial.passed).toBe(true);
+    expect(score.coverage.ratio).toBeLessThan(0.8);
+    expect(score.passed).toBe(false);
+  });
+
+  it('mcpScoreToDetails wraps the score under the mcp key for FabricScore.details', async () => {
+    const score = await assessMcpTarget(cfg());
+    const details = mcpScoreToDetails(score);
+    expect(details.mcp).toBe(score);
+    // merges cleanly into a FabricScore.details bag
+    const merged: Record<string, unknown> = { existing: 1, ...details };
+    expect(merged).toHaveProperty('existing', 1);
+    expect(merged).toHaveProperty('mcp');
+  });
+});

--- a/src/mcp-target/score.ts
+++ b/src/mcp-target/score.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP target scoring (#47) — combines discovery coverage (#44) and the protocol
+ * probe battery (#46) into a single assessment, shaped for `FabricScore.details.mcp`.
+ *
+ * Per the agreed decision, MCP results live under `FabricScore.details.mcp` (the
+ * open escape hatch) rather than a new entry in the closed `dimensions` union, so
+ * existing typed consumers are unaffected. The exercised protocol version is
+ * carried in the artifact so a later run against a newer server is distinguishable.
+ */
+
+import { McpExecutor, McpTargetConfig } from './executor';
+import { runMcpCoverage } from './discovery';
+import { runProtocolProbes } from './probes';
+
+export interface McpTargetScore {
+  /** Optional capability profile the target claims to implement (e.g. 'read-only-surface'). */
+  surface?: string;
+  /** Protocol version actually negotiated/exercised this run. */
+  protocolVersion?: string;
+  coverage: {
+    toolsTotal: number;
+    covered: number;
+    uncovered: number;
+    skippedByPolicy: number;
+    unsupportedSchemas: number;
+    ratio: number;
+  };
+  adversarial: {
+    secure: number;
+    violations: number;
+    inconclusive: number;
+    /** True if no advertised tool had a fuzzable schema (schema enforcement unverified). */
+    schemaProbeSkipped: boolean;
+    passed: boolean;
+  };
+  /** Overall gate: adversarial held AND coverage met the threshold. */
+  passed: boolean;
+}
+
+export interface AssessMcpTargetOptions {
+  /** Capability profile label, echoed into the score. */
+  surface?: string;
+  /** Exercise write/destructive tools in coverage too (needs the executor's allowWrites). */
+  includeWrites?: boolean;
+  /** Minimum coverage ratio (0–1) required to pass. Default 0 (coverage informational). */
+  coverageThreshold?: number;
+  log?: (message: string) => void;
+}
+
+/**
+ * Assess an MCP target end-to-end: discover + measure coverage, then run the
+ * generic protocol probe battery. Returns a `details.mcp`-shaped score.
+ */
+export async function assessMcpTarget(config: McpTargetConfig, opts: AssessMcpTargetOptions = {}): Promise<McpTargetScore> {
+  const log = opts.log ?? (() => undefined);
+  const threshold = opts.coverageThreshold ?? 0;
+
+  const exec = new McpExecutor(config);
+  const coverage = await runMcpCoverage(exec, { includeWrites: opts.includeWrites, log });
+  const probes = await runProtocolProbes(config, { log });
+
+  const coverageMet = coverage.coverageRatio >= threshold;
+  return {
+    surface: opts.surface,
+    protocolVersion: coverage.protocolVersion ?? exec.negotiatedProtocolVersion,
+    coverage: {
+      toolsTotal: coverage.toolsTotal,
+      covered: coverage.covered.length,
+      uncovered: coverage.uncovered.length,
+      skippedByPolicy: coverage.skippedByPolicy.length,
+      unsupportedSchemas: coverage.unsupportedSchemas.length,
+      ratio: coverage.coverageRatio,
+    },
+    adversarial: {
+      secure: probes.secure,
+      violations: probes.violations,
+      inconclusive: probes.inconclusive,
+      schemaProbeSkipped: probes.schemaProbeSkipped,
+      passed: probes.passed,
+    },
+    passed: probes.passed && coverageMet,
+  };
+}
+
+/**
+ * Wrap an McpTargetScore for merging into `FabricScore.details`:
+ *   score.details = { ...score.details, ...mcpScoreToDetails(mcp) }
+ */
+export function mcpScoreToDetails(score: McpTargetScore): { mcp: McpTargetScore } {
+  return { mcp: score };
+}

--- a/src/mcp-target/score.ts
+++ b/src/mcp-target/score.ts
@@ -55,7 +55,10 @@ export async function assessMcpTarget(config: McpTargetConfig, opts: AssessMcpTa
   const log = opts.log ?? (() => undefined);
   const threshold = opts.coverageThreshold ?? 0;
 
-  const exec = new McpExecutor(config);
+  // includeWrites is the user-facing write opt-in for the assessment — make it
+  // self-sufficient by enabling the executor's write guard, so coverage doesn't
+  // throw McpWriteBlockedError at the first destructive tool.
+  const exec = new McpExecutor({ ...config, allowWrites: opts.includeWrites ? true : config.allowWrites });
   const coverage = await runMcpCoverage(exec, { includeWrites: opts.includeWrites, log });
   const probes = await runProtocolProbes(config, { log });
 


### PR DESCRIPTION
Closes #47. Plain PR off `main`. Fifth Phase-A deliverable of epic #42 — builds on coverage (#44) + probes (#46) now on main.

## What
`assessMcpTarget(config, opts)` — runs discovery coverage + the protocol probe battery and returns a **`FabricScore.details.mcp`-shaped** score:

```ts
{
  surface?, protocolVersion,            // exercised version carried in the artifact
  coverage: { toolsTotal, covered, uncovered, skippedByPolicy, unsupportedSchemas, ratio },
  adversarial: { secure, violations, inconclusive, schemaProbeSkipped, passed },
  passed,                               // adversarial held AND coverage ≥ threshold
}
```

## Decisions honored
- **`details.mcp`, not a new dimension** — `FabricScore.dimensions` is a closed typed union; using the `details` escape hatch leaves every existing typed consumer untouched. `mcpScoreToDetails()` wraps it for a clean `{ ...score.details, ...mcpScoreToDetails(mcp) }` merge.
- **Exercised protocol version in the artifact** (the prior P3) — so a later run against a newer server is distinguishable.
- Optional `coverageThreshold` gate + `surface` capability-profile label.

## Tests
+3: combined score shape, coverage-threshold gating (fails overall even when probes pass), `details.mcp` merge. **All 7 mcp-target files green in isolation (70 tests), tsc strict, package-surface + boundary pass.**

> Note: the single-process local `npm test` shows intermittent cross-file flakes in *pre-existing* suites (`mcp-client`, `init`, etc.) under resource contention — CI runs each file isolated via `--runTestsByPath`, so it's unaffected. (The release-readiness timeout flake was already fixed in #55.)

## Last one
#48 = docs + example + CHANGELOG + **v0.5.0 publish** — the release that unblocks the Redy dogfood (#1390).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
