### PR TITLE
release: v0.5.0 — MCP target testing (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Scan published package surface
         run: npm run check:package-surface
 
+      - name: Check release hygiene (no tracked node_modules, lockfile version)
+        run: npm run check:release
+
       - name: Verify npm package contents
         run: npm pack --dry-run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.0] — 2026-06-13 — MCP target testing
+
+Point STF at **any product's MCP server** and run closed-loop coverage +
+adversarial verification — the inverse of `fab-mcp`. MCP is the system under
+test, not the harness. Targets protocol version `2025-03-26` (negotiated).
+
+### Added — MCP target testing
+- `McpExecutor` — Streamable-HTTP MCP target client. Initialize/session lifecycle,
+  protocol-version negotiation, both JSON and SSE response forms, stale-session
+  (404) reinitialize-and-retry, paginated `tools/list`, `previewThenCommit`.
+  Records a BehaviorEvent per `tools/call`. Read-only by default (`allowWrites`).
+- `classifyMcpOutcome` — maps JSON-RPC `error.code` / `result.isError` onto the
+  existing `BEHAVIOR_OUTCOMES` (errors ride over HTTP 200 — classified on the
+  JSON-RPC layer, not HTTP status). No schema migration.
+- `runMcpCoverage` + `generateInputs` + `snapshotCatalog`/`diffCatalog` — discovery
+  with schema-driven coverage, boundary-invalid input generation, unsupported-construct
+  reporting, and annotation-aware catalog drift detection.
+- `runProtocolProbes` — generic, protocol-portable adversarial battery (unauthenticated,
+  malformed JSON-RPC, unknown tool, schema-violating args, stale/missing session,
+  unsupported version). Per-probe expected-secure on the JSON-RPC layer; hard gate
+  on violation **or** inconclusive.
+- `assessMcpTarget` + `mcpScoreToDetails` — combined assessment shaped for
+  `FabricScore.details.mcp`, carrying the exercised protocol version.
+- `startFixture` — a compliant Streamable-HTTP MCP fixture server, exported as a
+  conformance double for your own tests. See `docs/mcp-target-testing.md` and
+  `demo/mcp-target.ts`.
+
+### Changed — CI
+- Raised the release-readiness tarball-install test timeout (native-dep reinstall
+  routinely ~90–100s on CI runners).
+
+---
+
 ## [0.4.0] — 2026-05-10 — agent-friendly surface
 
 The CLI surface a Claude Code (or similar) agent can drive end-to-end.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,27 @@ unexplored scenarios; low `regression_health` flags regressions immediately.
 
 ---
 
+## What's new in v0.5.0 — MCP target testing
+
+Point STF at **any product's MCP server** and run closed-loop coverage +
+adversarial verification — the way an agent will actually use it (the inverse of
+`fab-mcp`, where MCP is the *system under test*). MCP is self-describing, so STF
+discovers your surface, auto-derives coverage, and ships a portable protocol probe
+battery. One call:
+
+```ts
+import { assessMcpTarget } from 'synthetic-test-fabric';
+const score = await assessMcpTarget({ endpoint: 'https://app/mcp', dbPath: '.lisa_memory/lisa.db',
+  simulationId: 'ci', agentId: 'probe', token: process.env.MCP_TOKEN });
+if (!score.passed) throw new Error('MCP target failed'); // → FabricScore.details.mcp
+```
+
+Read-only by default (safe against prod), classifies on the JSON-RPC layer (errors
+ride over HTTP 200), targets protocol `2025-03-26`. See
+[docs/mcp-target-testing.md](docs/mcp-target-testing.md) and `demo/mcp-target.ts`.
+
+---
+
 ## What's new in v0.4.0
 
 The CLI surface a Claude Code (or similar) agent can drive end-to-end. Same engine
@@ -151,6 +172,7 @@ Full changelog: [CHANGELOG.md](CHANGELOG.md).
 | **Visual regression** | `VisualRegression.capture/compare` with pixelmatch; baselines managed via `fab baseline` |
 | **HTML trend report** | `HtmlReporter` generates a self-contained report with Chart.js trend across the last 30 iterations |
 | **Headless HTTP** | `ApiExecutor` records behavior events without a browser — 80× faster than Playwright for simulation |
+| **MCP target testing** | `assessMcpTarget` / `runProtocolProbes` / `runMcpCoverage` drive any MCP server as a system-under-test → `FabricScore.details.mcp`. See [docs/mcp-target-testing.md](docs/mcp-target-testing.md) |
 | **LLM element inference** | `@kaneshir/lisa-mcp` peer gives BrowserAdapter AI-driven key discovery via the Lisa MCP server |
 | **LLM-agnostic flow generation** | `LISA_LLM_PROVIDER=anthropic\|openai\|gemini` swaps the GENERATE_FLOWS LLM without code changes |
 

--- a/demo/mcp-target.ts
+++ b/demo/mcp-target.ts
@@ -1,0 +1,63 @@
+/**
+ * demo/mcp-target.ts — MCP target testing demo for synthetic-test-fabric (#48).
+ *
+ * Spins up the bundled compliant MCP fixture server, then drives it as a target:
+ * discovers the catalog, measures coverage, runs the generic protocol probe
+ * battery, and prints the `details.mcp`-shaped assessment. No real backend, no
+ * secrets — point `assessMcpTarget` at any MCP endpoint to test your own.
+ *
+ * Usage:
+ *   npm run build && npx tsx demo/mcp-target.ts
+ */
+import {
+  startFixture,
+  assessMcpTarget,
+  runProtocolProbes,
+  runMcpCoverage,
+  McpExecutor,
+} from '../dist/index.js';
+
+async function main(): Promise<void> {
+  const fixture = await startFixture();
+  console.log(`▶ MCP fixture listening at ${fixture.url}\n`);
+
+  const config = {
+    endpoint: fixture.url,
+    dbPath: '', // demo: not recording behavior events
+    simulationId: 'demo',
+    agentId: 'demo-agent',
+    token: 'valid-aal2',
+  };
+
+  try {
+    // 1. Discover the advertised catalog.
+    const exec = new McpExecutor(config);
+    const tools = await exec.listTools();
+    console.log(`Discovered ${tools.length} tools: ${tools.map((t) => t.name).join(', ')}\n`);
+
+    // 2. Coverage — invoke each tool with a schema-generated valid input (read-only by default).
+    const coverage = await runMcpCoverage(exec, { log: (m) => console.log(`  · ${m}`) });
+    console.log(
+      `Coverage: ${coverage.covered.length}/${coverage.toolsTotal - coverage.skippedByPolicy.length} in-policy ` +
+        `(ratio ${(coverage.coverageRatio * 100).toFixed(0)}%), ${coverage.skippedByPolicy.length} write(s) skipped\n`,
+    );
+
+    // 3. Generic protocol probe battery.
+    const probes = await runProtocolProbes(config);
+    console.log(`Adversarial: ${probes.secure} secure, ${probes.violations} violations, ${probes.inconclusive} inconclusive`);
+    for (const r of probes.results) console.log(`  ${r.verdict === 'secure' ? '✓' : '✗'} ${r.name} (${r.verdict})`);
+    console.log('');
+
+    // 4. Combined assessment — the FabricScore.details.mcp shape.
+    const score = await assessMcpTarget(config, { surface: 'read-only-surface' });
+    console.log('details.mcp =', JSON.stringify(score, null, 2));
+    console.log(`\n${score.passed ? '✅ PASS' : '❌ FAIL'} — protocol ${score.protocolVersion}`);
+  } finally {
+    await fixture.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/mcp-target-testing.md
+++ b/docs/mcp-target-testing.md
@@ -1,0 +1,132 @@
+# MCP target testing
+
+Point Synthetic Test Fabric at **any MCP server** and run closed-loop coverage +
+adversarial verification — the way an agent will actually use it. This is the
+inverse of `fab-mcp` (which exposes STF *itself* over MCP): here an MCP server is
+the **system under test**.
+
+MCP is self-describing (`tools/list` returns a JSON Schema per tool), so STF can
+discover your surface, auto-derive coverage, and ship a **portable protocol probe
+battery** that works against any compliant server.
+
+> Targets the MCP protocol version **`2025-03-26`** (negotiated from `initialize`;
+> additional versions can be configured).
+
+---
+
+## Quick start
+
+```ts
+import { assessMcpTarget } from 'synthetic-test-fabric';
+
+const score = await assessMcpTarget({
+  endpoint: 'https://your-app.example.com/mcp',
+  dbPath: '.lisa_memory/lisa.db',   // behavior events are recorded here
+  simulationId: 'ci-run-1',
+  agentId: 'mcp-probe',
+  token: process.env.MCP_ACCESS_TOKEN,   // or: tokenProvider: async () => mintToken()
+  // protocolVersions: ['2025-03-26'],    // preferred-first; negotiated at initialize
+  // allowWrites: false,                  // read-only by default (see Safety)
+});
+
+if (!score.passed) throw new Error('MCP target assessment failed');
+```
+
+`assessMcpTarget` returns a `FabricScore.details.mcp`-shaped object:
+
+```jsonc
+{
+  "surface": "read-only-surface",
+  "protocolVersion": "2025-03-26",      // version actually exercised
+  "coverage": { "toolsTotal": 8, "covered": 6, "uncovered": 1,
+                "skippedByPolicy": 1, "unsupportedSchemas": 0, "ratio": 0.857 },
+  "adversarial": { "secure": 8, "violations": 0, "inconclusive": 0,
+                   "schemaProbeSkipped": false, "passed": true },
+  "passed": true
+}
+```
+
+Merge it into a `FabricScore`:
+
+```ts
+import { mcpScoreToDetails } from 'synthetic-test-fabric';
+fabricScore.details = { ...fabricScore.details, ...mcpScoreToDetails(score) };
+```
+
+---
+
+## The pieces
+
+You can use the layers directly instead of `assessMcpTarget`:
+
+| Export | What it does |
+|--------|--------------|
+| `McpExecutor` | Streamable-HTTP target client: handshake, session, `tools/list` (paginated), `tools/call`, `previewThenCommit`. Records a BehaviorEvent per call. |
+| `runMcpCoverage(executor, opts)` | Invokes each advertised tool with a schema-generated valid input; reports covered / uncovered / `skippedByPolicy` / unsupported-schema + ratio. |
+| `runProtocolProbes(config)` | The generic protocol probe battery (below). |
+| `snapshotCatalog` / `diffCatalog` | Pin the catalog (names + schema hashes + coverage-relevant annotations); flag drift. |
+| `generateInputs(schema)` | JSON-Schema → valid + boundary-invalid inputs + unsupported-construct report. |
+
+---
+
+## Protocol probe battery
+
+`runProtocolProbes` fires portable, protocol-level probes and classifies each on
+the **JSON-RPC layer** (rejections ride over HTTP 200). Each probe declares its
+own expected-secure signal, so a stale-session `404` is *secure* for the
+stale-session probe — not "inconclusive".
+
+| Probe | Expected-secure |
+|-------|-----------------|
+| unauthenticated | `-32001` / HTTP 401 |
+| malformed (missing `jsonrpc`) | `-32600` |
+| malformed (parse error) | `-32700` |
+| unknown tool | `-32004` / `-32601` |
+| schema-violating args | `-32602` |
+| stale session | HTTP 404 |
+| missing session | 404 / `-32001` |
+| unsupported protocol version | `-32602` |
+
+**Hard gate:** a `violation` (succeeded where rejection was expected) **or** an
+`inconclusive` (rejected the wrong way — a crash/typo must not pass) fails the battery.
+
+**Out of scope by design:** product-specific authz probes (OAuth audience binding,
+AAL/step-up, cross-org, confirmation-token forgery, idempotency abuse) belong in
+*your* adopter layer — they depend on your policy, not the protocol.
+
+---
+
+## Safety: read-only by default
+
+Write/destructive tools are **never invoked** unless you opt in:
+
+```ts
+await assessMcpTarget(config, { includeWrites: true });  // forces the executor's write guard
+```
+
+Without `includeWrites`, write tools (detected via `destructiveHint`) are skipped
+and logged — never silently. A tool whose write status can't be determined is left
+to your server's authz rather than called. This makes it safe to run against a
+production endpoint.
+
+---
+
+## Try it
+
+A runnable demo spins up the bundled compliant fixture and assesses it end-to-end:
+
+```bash
+npm run build && npx tsx demo/mcp-target.ts
+```
+
+The same `startFixture()` is exported, so you can use it as a **conformance double**
+in your own tests:
+
+```ts
+import { startFixture, runProtocolProbes } from 'synthetic-test-fabric';
+
+const fx = await startFixture();
+const result = await runProtocolProbes({ endpoint: fx.url, dbPath: '', simulationId: 't', agentId: 'a', token: 'valid-aal2' });
+expect(result.passed).toBe(true);
+await fx.close();
+```

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -340,6 +340,23 @@ Drop-in `Reporter` implementations included in the package.
 
 ---
 
+## MCP fixture (conformance double, #48)
+
+A compliant Streamable-HTTP MCP server you can point the target tester at in your own tests — no real backend, no secrets.
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `startFixture` | function | Boot an in-process compliant MCP server: `startFixture(config?) => Promise<FixtureHandle>` (sessions+expiry, JSON+SSE, scope/AAL gating, preview/commit, paginated `tools/list`). |
+| `DEFAULT_TOOLS` | const | Default fixture tool catalog (read / scope-gated / AAL2-write / broken). |
+| `DEFAULT_TOKENS` | const | Default token registry (`valid-readonly` / `valid-aal2` / `wrong-aud` / `expired`). |
+| `DEFAULT_PROTOCOL_VERSION` | const | `'2025-03-26'`. |
+| `JSON_RPC` | const | JSON-RPC error-code constants (`UNAUTHORIZED`, `FORBIDDEN`, …). |
+| `FixtureHandle` | type | `{ url, port, close(), expireAllSessions(), mutationCount() }`. |
+| `FixtureConfig` | type | Server config (tools, tokens, protocol versions, session TTL, page size, endpoint path). |
+| `FixtureTool` / `FixtureToken` / `Aal` | type | Catalog + token shapes. |
+
+---
+
 ## Misc
 
 | Export | Kind | Description |

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/derek/src/synthetic-test-fabric/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/derek/src/synthetic-test-fabric/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "eslint . --ext .ts",
     "check:boundary": "npx tsx scripts/check-boundary.ts",
     "check:package-surface": "npx tsx scripts/check-package-surface.ts",
+    "check:release": "npx tsx scripts/check-release.ts",
     "check:demo": "npm run build && tsc --project tsconfig.demo.json --noEmit",
     "check:fixtures": "tsc --project tsconfig.fixtures.json --noEmit",
     "demo": "npx tsx demo/run.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Generic engine for autonomous synthetic test loops: simulation → browser flows → scoring → feedback",
   "keywords": [
     "testing",
@@ -99,6 +99,7 @@
     "docs/lisa-mcp.md",
     "docs/cli-json-output.md",
     "docs/mcp-install.md",
+    "docs/mcp-target-testing.md",
     "docs/claude-skills/README.md",
     "docs/claude-skills/skills/stf/",
     "docs/claude-skills/agents/stf-runner.md",

--- a/scripts/check-release.ts
+++ b/scripts/check-release.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env tsx
+/**
+ * check-release.ts — release hygiene guard.
+ *
+ *  1. No tracked `node_modules` — a committed dir/symlink bakes a local absolute
+ *     path (or vendored deps) into the repo. Dev worktrees often symlink it;
+ *     `.gitignore`'s `node_modules/` matches directories but NOT a symlink, so
+ *     `git add -A` can stage it. This fails the build before that ships.
+ *  2. package.json version matches package-lock.json (root + packages[""]), so a
+ *     release bump can't leave the lockfile inconsistent.
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const failures: string[] = [];
+
+// 1. tracked node_modules
+try {
+  const tracked = execFileSync('git', ['ls-files', 'node_modules'], { encoding: 'utf8' }).trim();
+  if (tracked) failures.push(`tracked node_modules entries (must never be committed):\n    ${tracked.split('\n').join('\n    ')}`);
+} catch {
+  // not a git checkout (e.g. inside a published tarball) — skip this check
+}
+
+// 2. version consistency
+const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
+const lock = JSON.parse(fs.readFileSync(path.resolve('package-lock.json'), 'utf8'));
+const v = pkg.version as string;
+if (lock.version !== v) failures.push(`package-lock.json root version ${lock.version} != package.json ${v}`);
+if (lock.packages?.['']?.version !== v) failures.push(`package-lock.json packages[""] version ${lock.packages?.['']?.version} != package.json ${v}`);
+
+if (failures.length) {
+  console.error('Release hygiene check FAILED:');
+  for (const f of failures) console.error('  - ' + f);
+  process.exit(1);
+}
+console.log(`Release hygiene check passed (version ${v}, no tracked node_modules).`);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -186,4 +186,21 @@ describe('public API surface (src/index.ts)', () => {
       expectExported(name);
     });
   });
+
+  describe('mcp fixture conformance double (#48)', () => {
+    it.each([
+      'startFixture',
+      'DEFAULT_TOOLS',
+      'DEFAULT_TOKENS',
+      'DEFAULT_PROTOCOL_VERSION',
+      'JSON_RPC',
+      'FixtureHandle',
+      'FixtureConfig',
+      'FixtureTool',
+      'FixtureToken',
+      'Aal',
+    ])('exports %s', (name) => {
+      expectExported(name);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ export { runProtocolProbes, classifyVerdict } from './mcp-target/probes';
 export type { ProbeVerdict, ProbeOutcome, ProbeResult, ProbeBatteryResult, ProbeOptions } from './mcp-target/probes';
 export { assessMcpTarget, mcpScoreToDetails } from './mcp-target/score';
 export type { McpTargetScore, AssessMcpTargetOptions } from './mcp-target/score';
+// MCP fixture — a compliant Streamable-HTTP MCP server you can point the target
+// tester at (in your own tests / conformance checks), so you don't need a real backend.
+export { startFixture, DEFAULT_TOOLS, DEFAULT_TOKENS, DEFAULT_PROTOCOL_VERSION, JSON_RPC } from './mcp-target/fixture-server';
+export type { FixtureHandle, FixtureConfig, FixtureTool, FixtureToken, Aal } from './mcp-target/fixture-server';
 export {
   LISA_DB_SCHEMA_VERSION,
   applyLisaDbMigrations,

--- a/src/mcp-target/executor.test.ts
+++ b/src/mcp-target/executor.test.ts
@@ -135,6 +135,13 @@ describe('McpExecutor (#43)', () => {
     expect(events.every((ev) => JSON.parse(ev.entity_refs!).surface === 'mcp')).toBe(true);
   });
 
+  it('records nothing (and never crashes) in assessment-only mode (empty dbPath)', async () => {
+    const e = new McpExecutor({ endpoint: fx.url, dbPath: '', simulationId: 'sim-1', agentId: 'a', token: 'valid-readonly' });
+    const r = await e.callTool('fixture.read.item', { id: 'x' });
+    expect(r.ok).toBe(true);
+    e.flush(); // no-op, no throw
+  });
+
   it('preserves the raw mcp_error_<code> in the event detail', async () => {
     const e = exec('valid-readonly');
     await e.callTool('fixture.read.restricted', {}); // -32003

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -301,8 +301,9 @@ export class McpExecutor {
     return { preview, commit };
   }
 
-  /** Flush buffered behavior events to disk. */
+  /** Flush buffered behavior events to disk. No-op in assessment-only mode (empty dbPath). */
   flush(): void {
+    if (!this.cfg.dbPath) return;
     try {
       BehaviorEventRecorder.getInstance(this.cfg.dbPath, 'simulation').flush();
     } catch {
@@ -360,6 +361,9 @@ export class McpExecutor {
     outcome_detail: string | null,
     toolName: string,
   ): void {
+    // No dbPath → assessment-only mode: don't record (and don't arm the
+    // recorder's flush timer against a schemaless/absent db).
+    if (!this.cfg.dbPath) return;
     try {
       BehaviorEventRecorder.getInstance(this.cfg.dbPath, 'simulation').record({
         execution_id: randomUUID(), // fresh per call → each call lands as its own event


### PR DESCRIPTION
Closes #48. **The v0.5.0 release PR — built up to, but NOT including, `npm publish`** (awaiting explicit go-ahead). Final Phase-A deliverable of epic #42.

## What's in this PR
- **`docs/mcp-target-testing.md`** — how to point STF at any MCP server: config, the probe battery, coverage, `details.mcp`, and the read-only safety model.
- **`demo/mcp-target.ts`** — runnable end-to-end: spins the bundled fixture → discover → coverage → protocol probes → `assessMcpTarget`. Exits clean (`✅ PASS — protocol 2025-03-26`).
- **Fixture promoted to a public conformance double** — `startFixture` + `DEFAULT_TOOLS`/`DEFAULT_TOKENS` + types exported, so adopters can test their own MCP server with no real backend. (Resolves the deferred #50 open question.)
- **Bug fix (surfaced by the demo):** empty `dbPath` is now assessment-only mode — the executor doesn't record (and doesn't arm the recorder's flush timer against a schemaless db), fixing a post-run crash. Regression test added.
- `package.json` **0.4.0 → 0.5.0** + `docs/mcp-target-testing.md` added to the `files` allowlist.
- `CHANGELOG [0.5.0]`, README "What's new in v0.5.0" + capability row, `package-exports.md` fixture section.

## Verification
- `build`, `check:demo`, **demo runs clean**, all **72 mcp-target tests** green in isolation, index export guard (91), `check:package-surface` + `check:boundary` pass.
- **`npm pack --dry-run`** → `synthetic-test-fabric-0.5.0.tgz` ships `docs/mcp-target-testing.md`, `demo/mcp-target.ts`, and all `dist/mcp-target/*.js`.

## ⛔ Publish gate
Once this merges + CI is green, the remaining step is `npm publish` (public, irreversible — Redy then pins `^0.5.0`). **I will not run it without an explicit go-ahead.**

## After publish → unblocks
Redy dogfood **#1390** (#1391 bumps `^0.5.0`, then #1392–#1394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
