### PR TITLE
docs: surface MCP target testing across value/human/LLM docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ framework for an autonomous QA loop. It is **not** a BlueSkil repo — it is
 product-neutral. BlueSkil is one consumer; a second product was onboarded
 without changing any framework code.
 
+As of v0.5.0 it also ships **MCP target testing** (`src/mcp-target/`): point STF
+at any MCP server as a *system under test* — schema-driven coverage + a portable
+protocol probe battery → `FabricScore.details.mcp`. This is the inverse of
+`fab-mcp` (which exposes STF itself over MCP). It is generic protocol testing —
+**no product-specific authz probes belong here** (those live in the adopter).
+
 Do not add BlueSkil-specific logic, fixture aliases, scenario names, or
 Firebase references to this repo.
 
@@ -27,6 +33,8 @@ src/                  Framework source (TypeScript)
   score.ts            Scoring dimension calculation
   screen-path.ts      Path extraction from behavior events
   persona.ts          Persona seeding utilities
+  mcp-target/         MCP target testing — McpExecutor, discovery (schema-gen),
+                      protocol probes, score, and a compliant fixture server
   *.test.ts           Unit tests (Jest)
 
 demo/                 Reference implementation (no external dependencies)

--- a/docs/claude-skills/agents/stf-runner.md
+++ b/docs/claude-skills/agents/stf-runner.md
@@ -27,6 +27,9 @@ report.
 - Don't modify `src/` or any framework code.
 - Don't make architectural decisions about scoring weights, simulation
   parameters, or scenario design.
+- **MCP target testing** (`assessMcpTarget` / `runProtocolProbes`, v0.5.0+) is a
+  library API, not a `fab` command — if the user wants to test an MCP server,
+  surface it back to the parent session (see `docs/mcp-target-testing.md`).
 
 ## Default workflow
 

--- a/docs/claude-skills/skills/stf/SKILL.md
+++ b/docs/claude-skills/skills/stf/SKILL.md
@@ -93,6 +93,39 @@ fab adapter validate src/adapters/MySlackReporter.ts --json
 fab doctor --json                       # confirm config still loads
 ```
 
+## Testing an MCP server (target testing, v0.5.0+)
+
+Separate from the QA loop above: STF can drive **any MCP server as a system under
+test** (the inverse of `fab-mcp`). This is a **library** capability — no `fab`
+command. Use it when the user says "test my MCP server", "check our MCP endpoint",
+"is our MCP tool surface safe/usable", or is shipping an MCP integration.
+
+One call does discovery + coverage + the protocol probe battery:
+
+```ts
+import { assessMcpTarget } from 'synthetic-test-fabric';
+
+const score = await assessMcpTarget({
+  endpoint: 'https://app/mcp',
+  dbPath: '',                          // '' = assessment-only (no recording)
+  simulationId: 'ci', agentId: 'probe',
+  token: process.env.MCP_TOKEN,        // or tokenProvider: async () => mintToken()
+});
+// → FabricScore.details.mcp shape: { coverage{…}, adversarial{…}, protocolVersion, passed }
+if (!score.passed) throw new Error('MCP target failed');
+```
+
+Key facts to remember:
+- **Read-only by default.** Write/destructive tools are skipped unless `{ includeWrites: true }`. Safe against prod.
+- **Classify on the JSON-RPC layer, never HTTP status** — MCP rejections ride over HTTP 200.
+- The probe battery is **protocol-portable only** (unauth, malformed JSON-RPC, unknown tool, schema-violating args, stale/missing session, bad version). Product-specific authz probes (OAuth audience, AAL, cross-org, token forgery, idempotency) belong in the **adopter's** code, not here.
+- Hard gate: a `violation` (succeeded where rejection expected) OR `inconclusive` fails the battery.
+- `startFixture()` is exported as a compliant conformance double for the adopter's own tests.
+
+Lower-level pieces if you need them: `McpExecutor` (drive calls), `runMcpCoverage`,
+`runProtocolProbes`, `snapshotCatalog`/`diffCatalog` (drift), `generateInputs`.
+Full guide: `docs/mcp-target-testing.md`.
+
 ## Anti-patterns to avoid
 
 - **Don't use `--json` and parse stdout text simultaneously.** `--json` mode

--- a/docs/for-qa-engineers.md
+++ b/docs/for-qa-engineers.md
@@ -30,6 +30,33 @@ The ratio shifts: instead of 70% maintenance + 30% strategy, it inverts.
 
 ---
 
+## If your product exposes an MCP server
+
+More products now ship an **MCP server** so AI agents (ChatGPT, Claude, Gemini,
+internal copilots) can drive them. That's a new test surface — and agents exercise
+it differently than a human clicking through a UI. STF tests it for you:
+
+```ts
+import { assessMcpTarget } from 'synthetic-test-fabric';
+const score = await assessMcpTarget({ endpoint: 'https://app/mcp', dbPath: '',
+  simulationId: 'ci', agentId: 'probe', token: process.env.MCP_TOKEN });
+if (!score.passed) throw new Error('MCP target failed'); // gate CI on it
+```
+
+It discovers your tool catalog, checks **coverage** of every advertised tool, and
+runs a **protocol probe battery** (unauthenticated calls, malformed requests,
+schema-violating args, stale sessions, …) — failing the gate on anything that
+should have been rejected but wasn't. It's **read-only by default**, so it's safe
+to point at production.
+
+What stays yours: the *product-specific* security probes — "can a free-tier token
+call a paid tool", "does cross-org isolation hold", "is the write-confirmation
+contract forgeable". STF gives you the generic protocol floor + coverage; your
+domain knowledge writes the authz probes on top. See
+[mcp-target-testing.md](./mcp-target-testing.md).
+
+---
+
 ## Your Expertise Becomes the System's Intelligence
 
 The highest-leverage thing you contribute to this system is **persona authorship**.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -105,6 +105,51 @@ custom dashboard rather than shelling out.
 
 ---
 
+## Testing an MCP server (target testing)
+
+Separate from the QA loop above, STF can point at **any MCP server and test it as
+a system under test** — the way an AI agent will actually use it. This is the
+*inverse* of `fab-mcp` (which exposes STF itself over MCP): here an MCP server is
+the target, not the harness.
+
+Why it matters: as products expose MCP surfaces for agents (ChatGPT, Claude,
+Gemini, internal copilots), those surfaces need testing the way HTTP APIs do — but
+MCP is self-describing, so STF can discover your tools, auto-derive coverage, and
+run a portable protocol probe battery with no bespoke test code.
+
+```ts
+import { assessMcpTarget } from 'synthetic-test-fabric';
+
+const score = await assessMcpTarget({
+  endpoint: 'https://your-app/mcp',
+  dbPath: '.lisa_memory/lisa.db',
+  simulationId: 'ci', agentId: 'probe',
+  token: process.env.MCP_TOKEN,
+});
+if (!score.passed) throw new Error('MCP target assessment failed');
+```
+
+You get, shaped as `FabricScore.details.mcp`:
+
+- **Coverage** — every advertised tool invoked with a schema-generated valid input
+  (read-only by default; writes opt-in), reporting covered / uncovered /
+  skipped-by-policy + a ratio, plus catalog **drift** detection.
+- **A protocol probe battery** — portable adversarial probes (unauthenticated,
+  malformed JSON-RPC, unknown tool, schema-violating args, stale/missing session,
+  unsupported version), classified on the JSON-RPC layer with a hard gate on
+  violations *and* inconclusive results.
+- The **exercised protocol version**, so a later run against a newer server is
+  distinguishable.
+
+It is **read-only by default** (safe to run against production) and
+**protocol-portable** — product-specific authz probes (OAuth audience, AAL,
+cross-org, idempotency) live in your adopter layer. A compliant fixture
+(`startFixture()`) ships as a conformance double for your own tests.
+
+See [mcp-target-testing.md](./mcp-target-testing.md) and `demo/mcp-target.ts`.
+
+---
+
 ## Lisa MCP — AI-driven browser automation
 
 `@kaneshir/lisa-mcp` is an optional peer package that ships a precompiled Lisa
@@ -217,6 +262,10 @@ When `@kaneshir/lisa-mcp` is wired, two additional dimensions are populated:
 |-----------|--------|
 | `flakiness` | `FlakinessTracker` — per-flow failure rates; quarantined flow list |
 | `adversarial` | Adversarial persona probe results — violations found and top violation types |
+
+MCP target assessments (above) populate `FabricScore.details.mcp` rather than a
+scoring dimension — coverage ratio, the adversarial probe tally, and the exercised
+protocol version. Merge it via `mcpScoreToDetails(score)`.
 
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -133,13 +133,17 @@ You get, shaped as `FabricScore.details.mcp`:
 
 - **Coverage** — every advertised tool invoked with a schema-generated valid input
   (read-only by default; writes opt-in), reporting covered / uncovered /
-  skipped-by-policy + a ratio, plus catalog **drift** detection.
+  skipped-by-policy + a ratio.
 - **A protocol probe battery** — portable adversarial probes (unauthenticated,
   malformed JSON-RPC, unknown tool, schema-violating args, stale/missing session,
   unsupported version), classified on the JSON-RPC layer with a hard gate on
   violations *and* inconclusive results.
 - The **exercised protocol version**, so a later run against a newer server is
   distinguishable.
+
+For catalog **drift** (a tool added/removed, a schema or `destructiveHint`
+changed), pin and compare separately with `snapshotCatalog` / `diffCatalog` — it's
+a standalone helper, not part of the `assessMcpTarget` score.
 
 It is **read-only by default** (safe to run against production) and
 **protocol-portable** — product-specific authz probes (OAuth audience, AAL,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,6 +4,16 @@ This document describes what's planned for Synthetic Test Fabric. It is a living
 
 ---
 
+## Recently shipped
+
+- **MCP target testing** ✅ *shipped in v0.5.0* — point STF at any MCP server as a
+  *system under test*: schema-driven coverage, a portable protocol probe battery,
+  catalog drift detection, and a `FabricScore.details.mcp` score. Read-only by
+  default; protocol-portable (product authz probes stay in the adopter). See
+  [mcp-target-testing.md](./mcp-target-testing.md).
+
+---
+
 ## Guiding principles
 
 Every item on this roadmap is evaluated against three questions:

--- a/docs/value-proposition.md
+++ b/docs/value-proposition.md
@@ -36,6 +36,26 @@ a test. The system gets smarter over time.
 
 ---
 
+## The next surface: testing what agents touch (v0.5.0)
+
+Software is growing a second front door. Alongside the human UI, products now
+expose **MCP servers** so AI agents can operate them directly — and that surface
+is shipping faster than anyone is testing it. An agent calling your tools fails in
+ways a human never would: malformed requests, missing authorization, schema drift,
+stale sessions.
+
+Synthetic Test Fabric now tests that surface too. Point it at any MCP endpoint and
+it discovers the tool catalog, measures coverage, and runs a portable battery of
+protocol-level adversarial probes — a CI gate on whether your agent-facing surface
+is **usable and safe**, with no bespoke test code. It is read-only by default
+(safe against production) and reports into the same `FabricScore`.
+
+The strategic point is the same one as the QA loop: the bottleneck isn't people,
+it's the absence of a system that exercises the surface the way it's actually used.
+For the agent era, that surface is MCP.
+
+---
+
 ## The Offshore Offset
 
 A senior QA engineer costs $120-180K/year. An offshore QA team of equivalent


### PR DESCRIPTION
Follow-up to the v0.5.0 release (#48). #48 shipped the reference guide (`docs/mcp-target-testing.md`), `package-exports.md`, and the CHANGELOG; this propagates the capability to the **discoverability + instruction** surfaces so humans and agents actually find it.

## Value / human
- **overview.md** — a 'Testing an MCP server (target testing)' section + `details.mcp` in the scoring table
- **value-proposition.md** — 'The next surface: testing what agents touch' (the agent-era angle)
- **for-qa-engineers.md** — a QA-facing how-to (read-only, CI-gate, what stays yours)
- **roadmap.md** — 'Recently shipped' ✅ v0.5.0

## LLM instructions
- **claude-skills/skills/stf/SKILL.md** — when/how to use `assessMcpTarget` (read-only default, JSON-RPC-layer classification, protocol-portable boundary, fixture double)
- **claude-skills/agents/stf-runner.md** — it's a library API, not a `fab` command → defer to parent
- **AGENTS.md** — `src/mcp-target/` in the layout + 'generic only, no product authz' reminder

Docs-only (7 files, +150). No blocked product strings; `check:package-surface` + `check:boundary` + `check:release` pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)