### PR TITLE
feat(mcp-target): 429-aware Retry-After backoff in the MCP executor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.5.0",
-  "description": "Generic engine for autonomous synthetic test loops: simulation → browser flows → scoring → feedback",
+  "version": "0.5.1",
+  "description": "Generic engine for autonomous synthetic test loops: simulation \u2192 browser flows \u2192 scoring \u2192 feedback",
   "keywords": [
     "testing",
     "qa",

--- a/src/mcp-target/executor.ratelimit.test.ts
+++ b/src/mcp-target/executor.ratelimit.test.ts
@@ -1,0 +1,66 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { McpExecutor, McpError } from './executor';
+
+/**
+ * 429 backoff: the executor must behave like a polite client — a rate-limited burst should self-pace and
+ * retry (honouring Retry-After), not fail the call. This is what lets a coverage gate run against a live,
+ * tier-rate-limited server (e.g. Redy's MCP endpoint on the `free` tier @ 30 req/min) instead of dying on
+ * the first 429. Uses dbPath:'' (assessment-only) so no recorder/db is needed.
+ */
+describe('McpExecutor 429 backoff', () => {
+  let server: http.Server;
+  let url: string;
+  let total = 0;
+  let mode: { rejectFirst: number } | { rejectAll: true } = { rejectFirst: 0 };
+
+  function rateLimited(res: http.ServerResponse): void {
+    res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '0' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32029, message: 'rate limited' } }));
+  }
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => (raw += c));
+      req.on('end', () => {
+        total += 1;
+        const reject = 'rejectAll' in mode ? true : total <= mode.rejectFirst;
+        if (reject) return rateLimited(res);
+        const method = (() => { try { return JSON.parse(raw).method; } catch { return ''; } })();
+        if (method === 'notifications/initialized') { res.writeHead(202); return res.end(); }
+        res.writeHead(200, { 'Content-Type': 'application/json', 'mcp-session-id': 'sess-1' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-03-26', capabilities: {} } }));
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+  });
+  afterAll(() => new Promise<void>((r) => server.close(() => r())));
+  beforeEach(() => { total = 0; });
+
+  const make = (extra = {}) =>
+    new McpExecutor({ endpoint: url, dbPath: '', simulationId: 's', agentId: 'a', token: 't', retryBackoffBaseMs: 1, ...extra });
+
+  it('retries through a burst of 429s and then succeeds (initialize completes)', async () => {
+    mode = { rejectFirst: 3 };
+    const exec = make({ rateLimitRetries: 5 });
+    await expect(exec.initialize()).resolves.toBeUndefined();
+    expect(exec.negotiatedProtocolVersion).toBe('2025-03-26');
+    expect(total).toBeGreaterThan(3); // 3 × 429, then a 200 (retry happened)
+  });
+
+  it('gives up after rateLimitRetries (bounded — never loops forever) and surfaces the failure', async () => {
+    mode = { rejectAll: true };
+    const exec = make({ rateLimitRetries: 2 });
+    await expect(exec.initialize()).rejects.toBeInstanceOf(McpError);
+    expect(total).toBe(3); // 1 initial attempt + 2 retries, then give up
+  });
+
+  it('with retries disabled (0), a single 429 fails immediately', async () => {
+    mode = { rejectAll: true };
+    const exec = make({ rateLimitRetries: 0 });
+    await expect(exec.initialize()).rejects.toBeInstanceOf(McpError);
+    expect(total).toBe(1); // no retry
+  });
+});

--- a/src/mcp-target/executor.ratelimit.test.ts
+++ b/src/mcp-target/executor.ratelimit.test.ts
@@ -13,9 +13,15 @@ describe('McpExecutor 429 backoff', () => {
   let url: string;
   let total = 0;
   let mode: { rejectFirst: number } | { rejectAll: true } = { rejectFirst: 0 };
+  // How the 429 advertises its retry delay: a delta-seconds header, an HTTP-date, or none (→ exp backoff).
+  let retryAfter: 'zero' | 'date' | 'none' = 'zero';
 
   function rateLimited(res: http.ServerResponse): void {
-    res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': '0' });
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (retryAfter === 'zero') headers['Retry-After'] = '0';
+    else if (retryAfter === 'date') headers['Retry-After'] = new Date(Date.now() + 300).toUTCString();
+    // 'none' → omit the header so the executor must fall back to exponential backoff + jitter
+    res.writeHead(429, headers);
     res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32029, message: 'rate limited' } }));
   }
 
@@ -37,7 +43,7 @@ describe('McpExecutor 429 backoff', () => {
     url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
   });
   afterAll(() => new Promise<void>((r) => server.close(() => r())));
-  beforeEach(() => { total = 0; });
+  beforeEach(() => { total = 0; retryAfter = 'zero'; });
 
   const make = (extra = {}) =>
     new McpExecutor({ endpoint: url, dbPath: '', simulationId: 's', agentId: 'a', token: 't', retryBackoffBaseMs: 1, ...extra });
@@ -62,5 +68,21 @@ describe('McpExecutor 429 backoff', () => {
     const exec = make({ rateLimitRetries: 0 });
     await expect(exec.initialize()).rejects.toBeInstanceOf(McpError);
     expect(total).toBe(1); // no retry
+  });
+
+  it('falls back to exponential backoff when the 429 carries NO Retry-After header', async () => {
+    mode = { rejectFirst: 2 };
+    retryAfter = 'none'; // exercises the baseMs * 2**attempt + jitter branch
+    const exec = make({ rateLimitRetries: 5, retryBackoffBaseMs: 1 });
+    await expect(exec.initialize()).resolves.toBeUndefined();
+    expect(total).toBeGreaterThan(2);
+  });
+
+  it('honours an HTTP-date Retry-After header', async () => {
+    mode = { rejectFirst: 1 };
+    retryAfter = 'date'; // Retry-After as an RFC HTTP-date, not delta-seconds
+    const exec = make({ rateLimitRetries: 5 });
+    await expect(exec.initialize()).resolves.toBeUndefined();
+    expect(total).toBeGreaterThan(1);
   });
 });

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -341,7 +341,7 @@ export class McpExecutor {
     const body = JSON.stringify(payload);
 
     const start = Date.now();
-    const maxRetries = this.cfg.rateLimitRetries ?? DEFAULT_RATE_LIMIT_RETRIES;
+    const maxRetries = Math.max(0, this.cfg.rateLimitRetries ?? DEFAULT_RATE_LIMIT_RETRIES); // clamp: a negative would loop forever
     const baseMs = this.cfg.retryBackoffBaseMs ?? DEFAULT_RETRY_BACKOFF_BASE_MS;
 
     for (let attempt = 0; ; attempt++) {
@@ -357,6 +357,9 @@ export class McpExecutor {
         // burst against a rate-limited server self-paces instead of failing the call.
         if (res.status === 429 && attempt < maxRetries) {
           const waitMs = retryAfterMs(res) ?? baseMs * 2 ** attempt + Math.floor(Math.random() * baseMs);
+          // Release the body before reusing the connection — undici/fetch keep-alive can stall the next
+          // request on this socket if the 429 body is left undrained.
+          await res.body?.cancel().catch(() => undefined);
           await delay(Math.min(waitMs, MAX_RETRY_WAIT_MS));
           continue;
         }

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -46,6 +46,14 @@ export interface McpTargetConfig {
   allowWrites?: boolean;
   /** Per-request timeout in ms. Default 30_000. */
   timeoutMs?: number;
+  /**
+   * On HTTP 429 (rate limited), retry the request up to this many times — honouring the server's
+   * `Retry-After` header when present, else exponential backoff + jitter (capped). A 429 means the
+   * request was NOT processed, so retrying is safe even for writes. Default 5; set 0 to disable.
+   */
+  rateLimitRetries?: number;
+  /** Base delay (ms) for the exponential backoff used when a 429 carries no `Retry-After`. Default 500. */
+  retryBackoffBaseMs?: number;
 }
 
 export interface McpToolMeta {
@@ -327,28 +335,43 @@ export class McpExecutor {
     if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
     if (this._protocolVersion) headers['MCP-Protocol-Version'] = this._protocolVersion;
 
+    // Build the body ONCE so a retried request keeps the same JSON-RPC id — it's the same logical call.
     const payload: Record<string, unknown> = { jsonrpc: '2.0', method, params };
     if (!opts.notification) payload.id = this.rpcId++;
+    const body = JSON.stringify(payload);
 
     const start = Date.now();
-    try {
-      const res = await fetch(this.cfg.endpoint, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(this.cfg.timeoutMs),
-      });
-      const sessionIdHeader = res.headers.get('mcp-session-id') ?? undefined;
-      const envelope = await parseBody(res);
-      return { envelope, sessionIdHeader, httpStatus: res.status, durationMs: Date.now() - start };
-    } catch (err) {
-      // Network / timeout → synthesize an envelope so callers still get an outcome.
-      const aborted = (err as Error)?.name === 'TimeoutError' || (err as Error)?.name === 'AbortError';
-      return {
-        envelope: { error: { code: aborted ? -32000 : -32000, message: aborted ? 'request timed out' : `transport error: ${(err as Error)?.message}` } },
-        httpStatus: 0,
-        durationMs: Date.now() - start,
-      };
+    const maxRetries = this.cfg.rateLimitRetries ?? DEFAULT_RATE_LIMIT_RETRIES;
+    const baseMs = this.cfg.retryBackoffBaseMs ?? DEFAULT_RETRY_BACKOFF_BASE_MS;
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const res = await fetch(this.cfg.endpoint, {
+          method: 'POST',
+          headers,
+          body,
+          signal: AbortSignal.timeout(this.cfg.timeoutMs),
+        });
+        // Polite-client backoff: a 429 means the request was NOT processed (safe to retry, even for a
+        // write). Honour Retry-After when present, else exponential backoff + jitter — both capped — so a
+        // burst against a rate-limited server self-paces instead of failing the call.
+        if (res.status === 429 && attempt < maxRetries) {
+          const waitMs = retryAfterMs(res) ?? baseMs * 2 ** attempt + Math.floor(Math.random() * baseMs);
+          await delay(Math.min(waitMs, MAX_RETRY_WAIT_MS));
+          continue;
+        }
+        const sessionIdHeader = res.headers.get('mcp-session-id') ?? undefined;
+        const envelope = await parseBody(res);
+        return { envelope, sessionIdHeader, httpStatus: res.status, durationMs: Date.now() - start };
+      } catch (err) {
+        // Network / timeout → synthesize an envelope so callers still get an outcome.
+        const aborted = (err as Error)?.name === 'TimeoutError' || (err as Error)?.name === 'AbortError';
+        return {
+          envelope: { error: { code: -32000, message: aborted ? 'request timed out' : `transport error: ${(err as Error)?.message}` } },
+          httpStatus: 0,
+          durationMs: Date.now() - start,
+        };
+      }
     }
   }
 
@@ -392,6 +415,25 @@ export class McpExecutor {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// 429 backoff defaults (overridable per McpTargetConfig).
+const DEFAULT_RATE_LIMIT_RETRIES = 5;
+const DEFAULT_RETRY_BACKOFF_BASE_MS = 500;
+const MAX_RETRY_WAIT_MS = 60_000; // never block a single attempt longer than this
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+/** Parse a `Retry-After` header (delta-seconds OR HTTP-date) into ms-from-now; null if absent/unparseable. */
+function retryAfterMs(res: Response): number | null {
+  const h = res.headers.get('retry-after');
+  if (!h) return null;
+  const secs = Number(h);
+  if (Number.isFinite(secs)) return Math.max(0, secs * 1000);
+  const when = Date.parse(h);
+  return Number.isNaN(when) ? null : Math.max(0, when - Date.now());
+}
 
 /** Parse an MCP response body as either plain JSON or a request-scoped SSE stream. */
 async function parseBody(res: Response): Promise<JsonRpcEnvelope> {


### PR DESCRIPTION
## Why
The MCP executor's `send()` fired one `fetch` and surfaced a `429` straight through. Against a tier-rate-limited server — e.g. a `free`-tier MCP endpoint at **30 req/min** — a coverage burst trips 429 mid-run and dies with an opaque `initialize failed: unknown` (the 429 body has no JSON-RPC message). A gate testing a **live** MCP server (the #42/#1390 "test any product's MCP server" use case) can't complete.

## What
Make the executor a **polite client**: on HTTP `429`, retry the request —
- honour the server's **`Retry-After`** header (delta-seconds *or* HTTP-date) when present,
- else **exponential backoff + jitter**, both capped at 60s.

A `429` means the request was **not processed**, so retry is safe even for write tools. The JSON-RPC `id` is built once and reused across retries (same logical call). Non-429 responses and transport errors are unchanged.

New `McpTargetConfig` knobs (back-compat defaults):
- `rateLimitRetries` — default **5**; set `0` to disable.
- `retryBackoffBaseMs` — default **500**.

## Tests
New suite (`executor.ratelimit.test.ts`) drives an inline server that 429s a burst then 200s:
- retries through the burst → `initialize()` completes;
- **bounded** — gives up after `rateLimitRetries` (never loops forever);
- `rateLimitRetries: 0` → fails on the first 429.

20/20 executor tests green, clean `tsc`, build compiles.

## Release
Patch-bumped to **0.5.1** (additive + backward-compatible). Downstream consumers (e.g. Redy's `@redy/test-fabric` MCP coverage gate) bump to `^0.5.1` to get the backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)