### PR TITLE
feat(mcp-target): classify framework-layer HTTP 4xx rejections (0.5.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetic-test-fabric",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetic-test-fabric",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Generic engine for autonomous synthetic test loops: simulation \u2192 browser flows \u2192 scoring \u2192 feedback",
   "keywords": [
     "testing",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export type { McpClientOptions, McpTool, McpCallResult } from './mcp-client';
 export { normalizeScreenPath } from './screen-path';
 export type { SyntheticConfig } from './config';
 export { loadSyntheticConfig } from './config';
-export { BEHAVIOR_OUTCOMES, classifyOutcome, classifyMcpOutcome } from './outcomes';
+export { BEHAVIOR_OUTCOMES, classifyOutcome, classifyMcpOutcome, httpStatusToMcpErrorCode } from './outcomes';
 export type { BehaviorOutcome } from './outcomes';
 export { McpExecutor, McpError, McpWriteBlockedError, toolToScreen } from './mcp-target/executor';
 export type {

--- a/src/mcp-target/executor.httpstatus.test.ts
+++ b/src/mcp-target/executor.httpstatus.test.ts
@@ -1,0 +1,74 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { McpExecutor } from './executor';
+import { classifyMcpOutcome, httpStatusToMcpErrorCode, BEHAVIOR_OUTCOMES } from '../outcomes';
+
+/**
+ * Framework-layer rejections: a real MCP server (NestJS/FastAPI/Express) often rejects at a guard
+ * BEFORE the JSON-RPC handler, returning a REST-style 4xx with NO JSON-RPC `error` envelope. The
+ * executor must classify that as the rejection it is — not silently bucket it as success — and
+ * synthesize a recognizable error code, so consumers (probes/gates) can read it.
+ */
+describe('McpExecutor — framework-layer HTTP rejections', () => {
+  let server: http.Server;
+  let url: string;
+  let toolStatus = 403; // status the server returns on tools/call
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => (raw += c));
+      req.on('end', () => {
+        const method = (() => { try { return JSON.parse(raw).method; } catch { return ''; } })();
+        if (method === 'initialize') {
+          res.writeHead(200, { 'Content-Type': 'application/json', 'mcp-session-id': 's1' });
+          return res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-03-26', capabilities: {} } }));
+        }
+        if (method === 'notifications/initialized') { res.writeHead(202); return res.end(); }
+        // tools/call → a NestJS-style REST error body, NOT a JSON-RPC envelope
+        res.writeHead(toolStatus, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ statusCode: toolStatus, code: 'COMMON_FORBIDDEN', error: 'Forbidden', message: 'Not a member of this organization' }));
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+  });
+  afterAll(() => new Promise<void>((r) => server.close(() => r())));
+
+  const make = () => new McpExecutor({ endpoint: url, dbPath: '', simulationId: 's', agentId: 'a', token: 't', allowWrites: true });
+
+  it('classifies a REST-style 403 (no JSON-RPC error) as ERROR_403 + a -32003 errorCode, not success', async () => {
+    toolStatus = 403;
+    const exec = make();
+    const r: any = await exec.callTool('redy.supplier.records.list', { orgId: 'foreign' }, { write: true });
+    expect(r.ok).toBe(false);
+    expect(r.outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_403); // ← was SUCCESS before the fix
+    expect(r.errorCode).toBe(-32003);                    // ← was undefined before the fix
+    expect(r.httpStatus).toBe(403);
+  });
+
+  it('maps a REST-style 404 to ERROR_404 + -32004', async () => {
+    toolStatus = 404;
+    const exec = make();
+    const r: any = await exec.callTool('redy.x.y', {}, { write: true });
+    expect(r.ok).toBe(false);
+    expect(r.outcome).toBe(BEHAVIOR_OUTCOMES.ERROR_404);
+    expect(r.errorCode).toBe(-32004);
+  });
+
+  // pure-function guarantees
+  it('classifyMcpOutcome: HTTP status is a FALLBACK only — JSON-RPC error still wins; 200 stays success', () => {
+    expect(classifyMcpOutcome({ error: { code: -32003 } }, 200)).toBe(BEHAVIOR_OUTCOMES.ERROR_403); // jsonrpc wins
+    expect(classifyMcpOutcome({}, 403)).toBe(BEHAVIOR_OUTCOMES.ERROR_403);                          // fallback to status
+    expect(classifyMcpOutcome({}, 200)).toBe(BEHAVIOR_OUTCOMES.SUCCESS);                            // ok
+    expect(classifyMcpOutcome({})).toBe(BEHAVIOR_OUTCOMES.SUCCESS);                                 // no status → unchanged
+  });
+
+  it('httpStatusToMcpErrorCode maps the canonical statuses', () => {
+    expect(httpStatusToMcpErrorCode(401)).toBe(-32001);
+    expect(httpStatusToMcpErrorCode(403)).toBe(-32003);
+    expect(httpStatusToMcpErrorCode(404)).toBe(-32004);
+    expect(httpStatusToMcpErrorCode(429)).toBe(-32029);
+    expect(httpStatusToMcpErrorCode(200)).toBeUndefined();
+  });
+});

--- a/src/mcp-target/executor.ts
+++ b/src/mcp-target/executor.ts
@@ -22,7 +22,7 @@
 
 import { randomUUID } from 'crypto';
 import { BehaviorEventRecorder } from '../recorder';
-import { classifyMcpOutcome, BehaviorOutcome, BEHAVIOR_OUTCOMES } from '../outcomes';
+import { classifyMcpOutcome, httpStatusToMcpErrorCode, BehaviorOutcome, BEHAVIOR_OUTCOMES } from '../outcomes';
 
 // ---------------------------------------------------------------------------
 // Public types (transport-agnostic surface)
@@ -261,17 +261,22 @@ export class McpExecutor {
     const { envelope, httpStatus, durationMs } = await this.sessionRequest('tools/call', { name, arguments: args });
 
     const isError = envelope.result?.isError === true;
-    const outcome = classifyMcpOutcome(envelope);
+    const outcome = classifyMcpOutcome(envelope, httpStatus);
     const ok = !envelope.error && !isError && httpStatus < 400;
+    // A framework-layer rejection (4xx, no JSON-RPC error) carries no protocol code — synthesize one
+    // from the HTTP status so callers can recognize the rejection by code (e.g. 403 → -32003).
+    const errorCode = envelope.error?.code ?? (httpStatus >= 400 ? httpStatusToMcpErrorCode(httpStatus) : undefined);
     const detail = envelope.error
       ? `mcp_error_${envelope.error.code}: ${envelope.error.message}`
       : isError
         ? 'mcp_result_isError'
-        : null;
+        : httpStatus >= 400
+          ? `http_${httpStatus}`
+          : null;
 
     this.record(`tools/call ${name}`, opts.entityId ?? this.cfg.agentId, opts.tick ?? this._tick, ok ? 'completed' : 'failed', outcome, detail, name);
 
-    return { ok, outcome, errorCode: envelope.error?.code, isError, raw: envelope, httpStatus, durationMs };
+    return { ok, outcome, errorCode, isError, raw: envelope, httpStatus, durationMs };
   }
 
   /**

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -81,7 +81,8 @@ export function classifyMcpOutcome(
   /**
    * The HTTP status the envelope arrived on. JSON-RPC errors ride over HTTP 200 (the primary path
    * below), so this is a FALLBACK only: a rejection at the framework/guard layer — a REST-style 4xx
-   * with no JSON-RPC `error` (NestJS/FastAPI/Express, etc.) — is still a rejection and must not be
+   * with no JSON-RPC `error` (typical of guard/middleware in common web frameworks) — is still a
+   * rejection and must not be
    * mis-classified as success. Optional + backward-compatible.
    */
   httpStatus?: number,

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -73,10 +73,19 @@ export function classifyOutcome(error: unknown): BehaviorOutcome {
  *
  * Maps onto the existing BEHAVIOR_OUTCOMES set — no schema migration required.
  */
-export function classifyMcpOutcome(envelope: {
-  error?: { code?: number } | null;
-  result?: { isError?: boolean } | null;
-}): BehaviorOutcome {
+export function classifyMcpOutcome(
+  envelope: {
+    error?: { code?: number } | null;
+    result?: { isError?: boolean } | null;
+  },
+  /**
+   * The HTTP status the envelope arrived on. JSON-RPC errors ride over HTTP 200 (the primary path
+   * below), so this is a FALLBACK only: a rejection at the framework/guard layer — a REST-style 4xx
+   * with no JSON-RPC `error` (NestJS/FastAPI/Express, etc.) — is still a rejection and must not be
+   * mis-classified as success. Optional + backward-compatible.
+   */
+  httpStatus?: number,
+): BehaviorOutcome {
   const code = envelope.error?.code;
   if (typeof code === 'number') {
     switch (code) {
@@ -94,5 +103,29 @@ export function classifyMcpOutcome(envelope: {
   }
   // A `result` flagged isError is a tool-level failure with no protocol code.
   if (envelope.result?.isError) return BEHAVIOR_OUTCOMES.ERROR_UNKNOWN;
+  // No JSON-RPC error code: fall back to the HTTP status so a framework-layer rejection (a guard
+  // returning a 4xx before the JSON-RPC handler) isn't silently bucketed as success.
+  if (typeof httpStatus === 'number' && httpStatus >= 400) {
+    return classifyOutcome({ status: httpStatus });
+  }
   return BEHAVIOR_OUTCOMES.SUCCESS;
+}
+
+/**
+ * Canonical HTTP-status → JSON-RPC-equivalent error code (the inverse of the switch above). Lets a
+ * transport synthesize an `errorCode` when a server rejects at the HTTP layer with no JSON-RPC body,
+ * so consumers can recognize the rejection by code regardless of how the server framed it.
+ */
+export function httpStatusToMcpErrorCode(status: number): number | undefined {
+  switch (status) {
+    case 401: return -32001;
+    case 403: return -32003;
+    case 404: return -32004;
+    case 429: return -32029;
+    case 400:
+    case 422: return -32602;
+    default:
+      if (status >= 500) return -32000;
+      return status >= 400 ? -32600 : undefined;
+  }
 }


### PR DESCRIPTION
## Why
`classifyMcpOutcome` read only the JSON-RPC `envelope.error.code`. But real MCP servers (NestJS/FastAPI/Express) often reject at a **guard before the JSON-RPC handler**, returning a **REST-style 4xx with no JSON-RPC `error`** (e.g. `403 {statusCode, code:"COMMON_FORBIDDEN"}`). With no JSON-RPC code, the executor classified that as `outcome:"success", errorCode:none` while `ok` was correctly `false` — **internally inconsistent, and unreadable to consumers**: a correctly-blocked cross-tenant call was indistinguishable from a silent pass. (Found dogfooding — it made the MCP gate's adversarial column report "inconclusive" on rejections that were actually correct 403s.)

## Fix (fallback only — JSON-RPC errors over HTTP 200 still win)
- **`classifyMcpOutcome(envelope, httpStatus?)`** — when there's no JSON-RPC error code and `httpStatus >= 400`, classify by HTTP status (403→`ERROR_403`, 401, 404, 429, …).
- **`httpStatusToMcpErrorCode(status)`** (new, exported) — canonical HTTP→JSON-RPC code map; `callTool` synthesizes `errorCode` from the status (403→`-32003`) so consumers recognize the rejection regardless of framing.
- **Invariant restored:** `ok=false` no longer classifies as `success`.

## Why it matters
Core to "**test any product's MCP server**" — framework-based servers don't emit tidy JSON-RPC envelopes for guard rejections. Without this the fabric mis-grades every framework-layer authz rejection as a pass.

## Tests
Inline server returns REST-style `403`/`404` with no JSON-RPC error → executor classifies `ERROR_403`/`-32003` + `ERROR_404`/`-32004` (was `SUCCESS`/none); plus pure-function guarantees (JSON-RPC errors still win, 200 stays success). **646/646 green**, clean `tsc`, `check:release` passes. Patch bump → **0.5.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)